### PR TITLE
feat: Lab 3 — agent improvement with critic loop and grounding checks

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -82,6 +82,85 @@ def get_messages(patient_id: str):
     return [m.model_dump(by_alias=True) for m in messages]
 
 
+# --- Search endpoints (Lab 3) ---
+# These let agent tools request specific slices of a patient record
+# instead of fetching the entire thing.
+
+
+def _contains(obj, keyword: str) -> bool:
+    """Recursively check if keyword appears in any string value of a Pydantic model or dict."""
+    if isinstance(obj, str):
+        return keyword in obj.lower()
+    if isinstance(obj, BaseModel):
+        return any(_contains(getattr(obj, f), keyword) for f in obj.model_fields)
+    if isinstance(obj, dict):
+        return any(_contains(v, keyword) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_contains(item, keyword) for item in obj)
+    return False
+
+
+@app.get("/patients/{patient_id}/demographics")
+def get_demographics(patient_id: str):
+    """Get just the demographics for a patient."""
+    patient = get_patient_or_404(patient_id)
+    return patient.demographics.model_dump(by_alias=True)
+
+
+@app.get("/patients/{patient_id}/conditions")
+def search_conditions(patient_id: str, q: str = ""):
+    """Search conditions by keyword. Returns all if no query given."""
+    patient = get_patient_or_404(patient_id)
+    return [
+        c.model_dump(by_alias=True) for c in patient.conditions
+        if not q or _contains(c, q.lower())
+    ]
+
+
+@app.get("/patients/{patient_id}/medications")
+def search_medications(patient_id: str, q: str = ""):
+    """Search medications by keyword. Returns all if no query given."""
+    patient = get_patient_or_404(patient_id)
+    return [
+        m.model_dump(by_alias=True) for m in patient.medications
+        if not q or _contains(m, q.lower())
+    ]
+
+
+@app.get("/patients/{patient_id}/labs")
+def search_labs(patient_id: str, test: str = ""):
+    """Search lab results by test name. Returns matching results with dates."""
+    patient = get_patient_or_404(patient_id)
+    test_lower = test.lower()
+    matches = []
+    for lab in patient.labs:
+        for panel in lab.panels:
+            for result in panel.results:
+                if not test or test_lower in result.test.lower():
+                    matches.append({
+                        "date": lab.date,
+                        "panel": panel.name,
+                        "test": result.test,
+                        "value": result.value,
+                        "unit": result.unit,
+                        "interpretation": result.interpretation,
+                    })
+    return sorted(matches, key=lambda r: r["date"], reverse=True)
+
+
+@app.get("/patients/{patient_id}/encounters")
+def search_encounters(patient_id: str, q: str = ""):
+    """Search encounters by keyword. Returns all if no query given."""
+    patient = get_patient_or_404(patient_id)
+    return [
+        e.model_dump(by_alias=True) for e in patient.encounters
+        if not q or _contains(e, q.lower())
+    ]
+
+
+# --- Agent proxy endpoints ---
+
+
 @app.get("/patients/{patient_id}/concerns")
 def get_concerns(patient_id: str):
     """Get the current concerns for a patient.

--- a/app/ui.py
+++ b/app/ui.py
@@ -126,7 +126,7 @@ def get_agent_status() -> dict:
         resp = requests.get(f"{API_URL}/agent/status", timeout=3)
         resp.raise_for_status()
         return resp.json()
-    except (requests.ConnectionError, requests.Timeout):
+    except (requests.ConnectionError, requests.Timeout, requests.HTTPError):
         return {"running": False, "last_run": "", "error": "Agent unavailable"}
 
 
@@ -136,7 +136,7 @@ def get_masking_status() -> bool | None:
         resp = requests.get(f"{AGENT_API_URL}/masking", timeout=3)
         resp.raise_for_status()
         return resp.json().get("enabled")
-    except (requests.ConnectionError, requests.Timeout):
+    except (requests.ConnectionError, requests.Timeout, requests.HTTPError):
         return None
 
 
@@ -146,7 +146,7 @@ def toggle_masking() -> bool | None:
         resp = requests.post(f"{AGENT_API_URL}/masking/toggle", timeout=3)
         resp.raise_for_status()
         return resp.json().get("enabled")
-    except (requests.ConnectionError, requests.Timeout):
+    except (requests.ConnectionError, requests.Timeout, requests.HTTPError):
         return None
 
 
@@ -156,7 +156,7 @@ def get_grounding_mode() -> str | None:
         resp = requests.get(f"{AGENT_API_URL}/grounding", timeout=3)
         resp.raise_for_status()
         return resp.json().get("mode")
-    except (requests.ConnectionError, requests.Timeout):
+    except (requests.ConnectionError, requests.Timeout, requests.HTTPError):
         return None
 
 
@@ -166,7 +166,7 @@ def toggle_grounding() -> str | None:
         resp = requests.post(f"{AGENT_API_URL}/grounding/toggle", timeout=3)
         resp.raise_for_status()
         return resp.json().get("mode")
-    except (requests.ConnectionError, requests.Timeout):
+    except (requests.ConnectionError, requests.Timeout, requests.HTTPError):
         return None
 
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -214,6 +214,7 @@ def render_patient_selector(patients: list[dict], inbox: list[dict],
         "Patient",
         options=[p["id"] for p in patients],
         format_func=lambda pid: label(patient_map[pid]),
+        key="selected_patient",
     )
 
 
@@ -309,32 +310,55 @@ def _related_row(text: str, button_key: str, **session_updates):
             st.rerun()
 
 
-def render_concerns(concerns: list[Concern], patient_id: str, messages: list[Message] = None):
-    """Render the concerns panel (populated by the agent)."""
+@st.fragment
+def render_concerns(patient_id: str, messages: list[Message] = None):
+    """Render the concerns panel (populated by the agent).
+
+    This is a Streamlit fragment — it can rerun independently without
+    rerunning the whole page. This lets the agent status poll without
+    blocking navigation in the rest of the UI.
+    """
     st.subheader("Concerns")
 
     # Agent controls
     status = get_agent_status()
+    # Treat "just triggered" the same as "running" — the background thread
+    # may not have acquired the lock by the time this rerun checks status.
+    is_running = status.get("running") or st.session_state.get("agent_just_triggered")
     col_btn, col_status = st.columns([1, 2])
     with col_btn:
-        if status.get("running"):
+        if is_running:
             st.button("Agent Running...", disabled=True)
         else:
             if st.button("Run Agent"):
                 trigger_agent(patient_id)
-                st.rerun()
+                st.session_state["agent_just_triggered"] = True
+                st.rerun(scope="fragment")
     with col_status:
-        if status.get("running"):
+        if is_running:
             st.caption("Agent is processing patients...")
         elif status.get("last_run"):
             st.caption(f"Last run: {status['last_run'][:19]}")
         if status.get("error"):
             st.caption(f"Error: {status['error']}")
 
-    # Auto-refresh while agent is running
+    # Clear the trigger flag once the status endpoint confirms running
     if status.get("running"):
+        st.session_state.pop("agent_just_triggered", None)
+
+    # Auto-refresh while agent is running (fragment-scoped, doesn't block the page)
+    if is_running:
+        st.session_state["agent_was_running"] = True
         time.sleep(3)
-        st.rerun()
+        st.rerun(scope="fragment")
+
+    # Agent just finished — clear cache so we pick up new concerns
+    if st.session_state.pop("agent_was_running", False):
+        st.cache_data.clear()
+        st.rerun(scope="fragment")
+
+    # Fetch concerns fresh (fragment may rerun independently of the page)
+    concerns = load_concerns(patient_id)
 
     # Display concerns sorted by urgency
     urgency_order = {"urgent": 0, "soon": 1, "routine": 2}
@@ -496,7 +520,6 @@ st.divider()
 
 patient = load_patient(selected_id)
 messages = load_messages(selected_id)
-concerns = all_concerns.get(selected_id, [])
 
 # Row 1: Medical record + Concerns
 col_record, col_concerns = st.columns([3, 2])
@@ -527,7 +550,7 @@ with col_record:
         render_history(patient)
 
 with col_concerns:
-    render_concerns(concerns, selected_id, messages)
+    render_concerns(selected_id, messages)
 
 # Row 2: Inbox + Conversation viewer
 st.divider()

--- a/app/ui.py
+++ b/app/ui.py
@@ -352,10 +352,12 @@ def render_concerns(patient_id: str, messages: list[Message] = None):
         time.sleep(3)
         st.rerun(scope="fragment")
 
-    # Agent just finished — clear cache so we pick up new concerns
+    # Agent just finished — clear cache so we pick up new concerns.
+    # Full rerun here (not fragment-scoped) so the patient selector
+    # urgency badges also update with the new concerns.
     if st.session_state.pop("agent_was_running", False):
         st.cache_data.clear()
-        st.rerun(scope="fragment")
+        st.rerun()
 
     # Fetch concerns fresh (fragment may rerun independently of the page)
     concerns = load_concerns(patient_id)

--- a/app/ui.py
+++ b/app/ui.py
@@ -150,6 +150,26 @@ def toggle_masking() -> bool | None:
         return None
 
 
+def get_grounding_mode() -> str | None:
+    """Check which grounding mode is active. Returns None if agent is unavailable."""
+    try:
+        resp = requests.get(f"{AGENT_API_URL}/grounding", timeout=3)
+        resp.raise_for_status()
+        return resp.json().get("mode")
+    except (requests.ConnectionError, requests.Timeout):
+        return None
+
+
+def toggle_grounding() -> str | None:
+    """Toggle grounding mode. Returns new mode, or None if agent is unavailable."""
+    try:
+        resp = requests.post(f"{AGENT_API_URL}/grounding/toggle", timeout=3)
+        resp.raise_for_status()
+        return resp.json().get("mode")
+    except (requests.ConnectionError, requests.Timeout):
+        return None
+
+
 # ======================
 # UI components
 # ======================
@@ -523,13 +543,21 @@ with col_viewer:
         st.subheader("Conversation")
         st.info("Select a patient to view messages.")
 
-# PII masking toggle — only visible when the agent API is running (Lab 2+)
+# Agent toggles — only visible when the agent API is running
 masking_status = get_masking_status()
-if masking_status is not None:
+grounding_mode = get_grounding_mode()
+if masking_status is not None or grounding_mode is not None:
     st.divider()
-    col_spacer, col_toggle = st.columns([4, 1])
-    with col_toggle:
-        label = "PII Masking: ON" if masking_status else "PII Masking: OFF"
-        if st.button(label, type="secondary" if masking_status else "primary"):
-            toggle_masking()
-            st.rerun()
+    col_spacer, col_masking, col_grounding = st.columns([3, 1, 1])
+    with col_masking:
+        if masking_status is not None:
+            label = "PII Masking: ON" if masking_status else "PII Masking: OFF"
+            if st.button(label, type="secondary" if masking_status else "primary"):
+                toggle_masking()
+                st.rerun()
+    with col_grounding:
+        if grounding_mode is not None:
+            label = f"Grounding: {grounding_mode.upper()}"
+            if st.button(label, type="secondary"):
+                toggle_grounding()
+                st.rerun()

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -34,7 +34,7 @@ Build a background agent that reads patient records and portal messages, identif
 The naive agent is a black box. Add tracing and structured logging so you can see every decision it makes and inspect its reasoning.
 
 ### [Lab 3: Improving Your Agent](./lab-3.md)
-Use observability data to identify failure modes. Add a critic agent to evaluate the primary agent's output, and Granite Guardian for content safety.
+Use observability data to identify failure modes. Add a critic agent to evaluate the primary agent's output, and Granite Guardian for groundedness detection.
 
 ### [Lab 4: Securing Data Used By The Agent](./lab-4.md)
 Move from "trust the code" to database-enforced access control with Postgres Row-Level Security. Map the threat model, apply least-privilege, and test against adversarial inputs.

--- a/docs/content/lab-1.md
+++ b/docs/content/lab-1.md
@@ -112,8 +112,8 @@ By the end of this lab, you will:
 - [x] Understand the ReAct loop (Observe → Reason → Act) and how it maps to LangGraph's `create_react_agent`
 - [x] Know the difference between an agent that *surfaces information* and one that *generates content* — and why it matters in healthcare
 - [x] Understand how Structured Outputs and constrained decoding eliminate JSON parsing headaches
-- [ ] Run the agent against synthetic patient data and examine its output
-- [ ] Identify the limitations of a naive implementation
+- [x] Run the agent against synthetic patient data and examine its output
+- [x] Identify the limitations of a naive implementation
 
 ---
 

--- a/docs/content/lab-2.md
+++ b/docs/content/lab-2.md
@@ -42,10 +42,10 @@ By the end of this lab, you will:
 
 - [x] Understand why agent observability requires different tooling than traditional software monitoring
 - [x] Know the difference between traces, spans, and the data they capture
-- [ ] Instrument a LangGraph agent with Langfuse using three lines of code
-- [ ] See raw PHI in your traces and understand the risk
-- [ ] Implement client-side PII masking so sensitive data never reaches the trace store
-- [ ] Use the Langfuse UI to inspect agent behavior: tool calls, token usage, cost, latency
+- [x] Instrument a LangGraph agent with Langfuse using three lines of code
+- [x] See raw PHI in your traces and understand the risk
+- [x] Implement client-side PII masking so sensitive data never reaches the trace store
+- [x] Use the Langfuse UI to inspect agent behavior: tool calls, token usage, cost, latency
 
 ---
 

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -1,84 +1,305 @@
 # Lab 3: Improving Your Agent
 
-**Duration:** ~20 minutes
+**Duration:** ~25 minutes
 
 ???+ abstract "What You'll Improve"
-    You have a working agent and you can see what it's doing. Now let's make it better. In this lab you'll use the observability data from Lab 2 to identify failure modes, then apply targeted improvements: better prompting, error recovery, and guardrails.
+    The observable agent from Lab 2 has problems you can now see in the traces: it hallucinates evidence, goes off-task, and dumps the entire patient record into every run. In this lab you'll apply the improvement cycle — **identify** failure modes in traces, **reproduce** them, and **fix** them with targeted changes.
+
+---
+
+## The Improvement Cycle
+
+Agent development is iterative. The cycle looks like this:
+
+```mermaid
+graph LR
+    A[Run agent] --> B[Inspect traces]
+    B --> C[Identify failure]
+    C --> D[Implement fix]
+    D --> A
+```
+
+Lab 2 gave you the **inspect** step. Lab 3 gives you the **fix** step.
 
 ---
 
 ## Learning Objectives
 
-- Use trace data to identify where the agent fails or loops
-- Improve agent reliability with better system prompts and constraints
-- Implement graceful error handling and retry logic
-- Add a human-in-the-loop approval step for high-stakes actions
+By the end of this lab, you will:
+
+- [x] Know how to use Langfuse traces to identify concrete agent failures
+- [ ] Replace dump-everything tools with keyword-based search tools
+- [ ] Add a critic agent that evaluates the primary agent's output in a loop
+- [ ] Implement hallucination detection using Granite Guardian
+- [ ] Compare LLM-as-judge vs. purpose-built grounding models
 
 ---
 
-## Overview
+## Prerequisites
 
-Common failure modes in the naive agent (visible once you have observability):
+This lab requires **Ollama** for running Granite Guardian locally.
 
-| Problem | Symptom | Fix |
-|---|---|---|
-| Infinite loops | Agent keeps calling the same tool | Max iterations + exit conditions |
-| Bad tool inputs | Tool errors cascade | Input validation + retry with feedback |
-| Hallucinated tools | Agent calls a tool that doesn't exist | Strict tool list enforcement |
-| Runaway actions | Agent takes unintended side effects | Human-in-the-loop for destructive actions |
-
----
-
-## Step 1: Fix Infinite Loops
-
-```python
-# TODO: add iteration limits and loop detection
-```
-
----
-
-## Step 2: Add Error Recovery
-
-```python
-# TODO: implement retry logic with error feedback to the model
-```
-
----
-
-## Step 3: Strengthen the System Prompt
-
-```python
-# TODO: add constraints and clearer behavioral guidelines
-```
-
----
-
-## Step 4: Add a Human Approval Gate
-
-```python
-# TODO: add human-in-the-loop for high-stakes tool calls
-```
-
----
-
-## Step 5: Verify Improvements with Observability
-
-Run the same test cases from Lab 1 and compare the traces side by side.
+1. Install [Ollama](https://ollama.com/)
+2. Pull the Granite Guardian model:
 
 ```bash
-# TODO: add comparison instructions
+ollama pull ibm/granite3.2-guardian
 ```
+
+???+ tip "Why Ollama?"
+    Granite Guardian runs locally — no API keys, no cloud dependency. Your patient data never leaves your machine, which matters when you're building hallucination detection for healthcare data.
 
 ---
 
-## What Did We Learn?
+## What Lab 2 Revealed
 
-A few targeted improvements dramatically change agent reliability:
+If you haven't already, run the Lab 2 agent and look at the traces in Langfuse. You'll find three problems:
 
-- Clear exit conditions prevent runaway loops
-- Error feedback to the model enables self-correction
-- Constrained prompts reduce hallucination and scope creep
-- Human gates are the last line of defense for irreversible actions
+### Problem 1: The agent hallucinates evidence
+
+Compare the tool call outputs (what the data says) with the agent's concerns (what it claims). You'll find evidence strings that cite lab values, dates, or medication names that don't match what the tools returned. The agent is confidently stating facts that aren't in the record.
+
+### Problem 2: The agent goes off-task
+
+Despite the system prompt saying "do not make clinical recommendations," the agent suggests diagnoses, proposes treatments, or drafts replies to patient messages. It's doing the doctor's job instead of organizing what the doctor needs to see.
+
+### Problem 3: Too much data, not enough focus
+
+The `get_patient_record` tool dumps the **entire** patient record on every call — demographics, all conditions, all medications, all labs, all encounters, all messages. This wastes tokens, increases cost, and gives the agent more opportunities to hallucinate from irrelevant data.
+
+???+ note "What about prompt injection?"
+    You might wonder whether a patient could craft a portal message that hijacks the agent. In this system, that risk is **ameliorated by design**: the agent runs in the background, and its output goes to the **doctor** — not back to the patient. The patient never sees agent output, so there's no feedback loop to exploit. This is a deliberate architectural defense, not an accident. Security is about threat models, not checklists.
+
+---
+
+## Step 1: Focused Search Tools
+
+Open `lab2/agent/tools.py` and look at `get_patient_record`:
+
+```python
+@tool
+def get_patient_record(patient_id: str) -> dict:
+    """Get a patient's full record: demographics, conditions, allergies,
+    medications, lab results, encounter history, messages, and social history."""
+    resp = requests.get(f"{API_URL}/patients/{patient_id}")
+    resp.raise_for_status()
+    return resp.json()
+```
+
+This returns *everything*. The agent has no reason to think about what's relevant — it gets it all for free.
+
+Now open `lab3/agent/tools.py`. The dump-everything tool is gone, replaced by keyword-based search tools:
+
+```python
+@tool
+def search_conditions(patient_id: str, keyword: str) -> list[dict]:
+    """Search a patient's conditions by keyword (e.g., 'diabetes', 'hypertension')."""
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/conditions",
+                        params={"q": keyword})
+    resp.raise_for_status()
+    return resp.json()
+```
+
+The agent must now specify *what* it's looking for. This forces it to reason about relevance: "The patient mentioned fatigue — let me search for thyroid conditions and check TSH labs." Instead of drowning in data, the agent investigates.
+
+???+ question "Think about this"
+    If we'd replaced `get_patient_record` with `get_conditions`, `get_medications`, `get_labs` (no keywords), what would the agent do? It would call all of them and reconstruct the full record. Keywords force intentional investigation.
+
+The search endpoints use a recursive keyword matcher — a keyword like "diabetes" finds matches in nested fields like `code.display`, `notes`, or `assessment`:
+
+```python
+def _contains(obj, keyword: str) -> bool:
+    """Recursively check if keyword appears in any string value."""
+    if isinstance(obj, str):
+        return keyword in obj.lower()
+    if isinstance(obj, BaseModel):
+        return any(_contains(getattr(obj, f), keyword) for f in obj.model_fields)
+    if isinstance(obj, dict):
+        return any(_contains(v, keyword) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_contains(item, keyword) for item in obj)
+    return False
+```
+
+Small functions, clear responsibilities. The search helper doesn't know about patients or tools — it just knows how to walk a data structure.
+
+---
+
+## Step 2: The Critic Loop
+
+Focused tools reduce noise, but the agent can still hallucinate and go off-task. We need something to **check its work**.
+
+The naive approach is to use the same LLM to evaluate its own output (LLM-as-judge). The problem: the LLM has the same biases and failure modes when judging as when generating. It's checking its own homework.
+
+Lab 3 addresses this with a **two-part evaluation loop**:
+
+1. **Grounding check** — verifies that evidence strings are supported by tool output data
+2. **Critic** — evaluates whether the agent stayed on task
+
+Both run inside a loop with the primary agent:
+
+```mermaid
+graph LR
+    A[Primary Agent] --> B[Grounding Check]
+    B --> C[Critic]
+    C -->|revisions needed| A
+    C -->|approved| D[Save Results]
+```
+
+### The grounding module
+
+Open `lab3/agent/grounding.py`. It has one job: given evidence claims and source data, determine which claims are supported.
+
+Two implementations behind a toggle:
+
+```python
+# "llm" = LLM-as-judge, "guardian" = Granite Guardian via Ollama
+grounding_mode: str = "guardian"
+```
+
+The **LLM-as-judge** path sends the evidence and source data to the same OpenAI model:
+
+```python
+def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+    llm = ChatOpenAI(model=model).with_structured_output(...)
+    result = llm.invoke(_JUDGE_PROMPT.format(context=context, evidence=...))
+    return result.verdicts
+```
+
+The **Granite Guardian** path uses a purpose-built model via Ollama:
+
+```python
+def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+    client = ollama.Client(host=OLLAMA_BASE_URL)
+    for claim in evidence:
+        response = client.chat(model=GUARDIAN_MODEL, messages=[...])
+        # Guardian outputs Yes (hallucination) or No (grounded)
+```
+
+Granite Guardian is a separate model fine-tuned specifically for groundedness detection. It avoids the self-evaluation problem — a different model with different training checks the work.
+
+### The critic module
+
+Open `lab3/agent/critic.py`. The critic receives concerns plus grounding results and evaluates on-task behavior:
+
+```python
+def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> CriticResult:
+    llm = ChatOpenAI(model=model).with_structured_output(CriticResult)
+    return llm.invoke(_CRITIC_PROMPT.format(
+        concerns=concerns_json,
+        grounding=grounding_json,
+    ))
+```
+
+The critic returns structured feedback per concern — what's wrong and how to fix it. If anything needs revision, the feedback goes back to the primary agent.
+
+### Wiring it together
+
+Open `lab3/agent/agent.py`. The `process_patient` function runs the loop:
+
+```python
+for revision in range(MAX_REVISIONS):
+    grounding_results = [
+        check_grounding(c.title, c.evidence, context)
+        for c in structured.concerns
+    ]
+    critic_result = critic_evaluate(concerns_json, grounding_results)
+
+    if critic_result.approved:
+        break
+
+    # Re-run primary agent with revision feedback
+    structured, context = _run_primary_agent(
+        patient_id, revision_feedback="\n".join(feedback_parts)
+    )
+```
+
+Each module has one job. The grounding module doesn't know about the critic. The critic doesn't know about tools. The agent module wires them together. When you read one file, you understand one thing.
+
+---
+
+## Step 3: Run the Improved Agent
+
+Start the system with the Lab 3 agent:
+
+```bash
+# Terminal 1: Main API
+uv run uvicorn app.api:app --port 8000
+
+# Terminal 2: Streamlit UI
+uv run streamlit run app/ui.py --server.port 8501
+
+# Terminal 3: Agent API (now using lab3)
+uv run uvicorn lab3.agent.api:app --port 8001
+```
+
+???+ tip "Make sure Ollama is running"
+    The default grounding mode is Granite Guardian, which needs Ollama. Start Ollama before running the agent, or toggle to LLM-as-judge mode using the UI button.
+
+Select a patient and click **Run Agent**. The agent will take longer than Lab 2 — it's running the full loop (primary agent → grounding → critic → possibly revise).
+
+---
+
+## Step 4: Compare in Langfuse
+
+Open Langfuse at [http://localhost:3000](http://localhost:3000) and look at the new trace. You'll see more spans than in Lab 2:
+
+- **Primary agent** spans (tool calls + reasoning)
+- **Grounding check** spans (one per concern)
+- **Critic** span (evaluation + feedback)
+- If revisions happened: a second round of all three
+
+???+ question "Compare traces"
+    Run the agent with both grounding modes and compare the traces:
+
+    1. Run with **Granite Guardian** (default)
+    2. Toggle to **LLM** mode using the button at the bottom of the UI
+    3. Run again on the same patient
+
+    Look at the grounding check spans. How do the two modes differ? Does one catch hallucinations the other misses? What's the latency difference?
+
+---
+
+## Step 5: Toggle Grounding Modes
+
+The **Grounding** button at the bottom of the UI toggles between `LLM` and `GUARDIAN` modes. This follows the same pattern as Lab 2's PII masking toggle — a runtime flag on the agent API:
+
+```python
+# In lab3/agent/api.py — same shape as the masking toggle
+@app.post("/grounding/toggle")
+def toggle_grounding():
+    import lab3.agent.grounding as g
+    g.grounding_mode = "llm" if g.grounding_mode == "guardian" else "guardian"
+    return {"mode": g.grounding_mode}
+```
+
+Try both modes on the same patient and compare the results in Langfuse. The key tradeoff:
+
+| | LLM-as-Judge | Granite Guardian |
+|---|---|---|
+| **Model** | Same OpenAI model | Purpose-built IBM model |
+| **Self-evaluation bias** | Yes — checking its own work | No — separate model |
+| **Cost** | Uses your OpenAI API quota | Free (local via Ollama) |
+| **Latency** | Fast (API call) | Depends on hardware |
+| **Accuracy** | Good at reasoning, prone to bias | Trained for this specific task |
+
+---
+
+## What's Working
+
+Three targeted improvements, driven by what we found in the traces:
+
+**Focused tools reduce noise.** The agent investigates instead of dumping. Traces show fewer tokens per run, lower cost, and more intentional tool selection. PHI exposure in traces drops because the agent only sees data it asked for.
+
+**The critic loop catches problems.** Hallucinated evidence and off-task behavior get flagged and revised. You can see the revision feedback in the traces — the agent's second attempt is typically better than its first.
+
+**Granite Guardian provides independent grounding.** A separate model checking the agent's evidence avoids the self-evaluation problem. You can compare both approaches in the traces and see the difference.
+
+---
+
+## What's Still Broken
+
+The agent is more reliable, but it still has unrestricted access to all patient data. Any tool can fetch any patient's records — there are no access controls, no scoping, no audit trail for who accessed what.
 
 ---
 
@@ -88,5 +309,5 @@ A few targeted improvements dramatically change agent reliability:
 |---|---|---|
 | ~~[Lab 1](lab-1.md)~~ | ~~No structure, no tools, just vibes~~ | ~~A ReAct agent with structured output~~ |
 | ~~[Lab 2](lab-2.md)~~ | ~~No visibility into agent behavior~~ | ~~Observability: Langfuse tracing, PII masking, cost tracking~~ |
-| ~~[Lab 3](lab-3.md)~~ | ~~Unstable output, hallucinations, overstepping~~ | ~~Evaluation: output validation, grounding checks, guardrails~~ |
+| ~~[Lab 3](lab-3.md)~~ | ~~Unstable output, hallucinations, overstepping~~ | ~~Evaluation: focused tools, critic loop, grounding checks~~ |
 | **[Lab 4](lab-4.md)** | Unrestricted data access | Security: scoped tools, access controls, audit trails |

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -250,8 +250,8 @@ uv run streamlit run app/ui.py --server.port 8501
 uv run uvicorn lab3.agent.api:app --port 8001
 ```
 
-???+ tip "Ollama is optional"
-    The default grounding mode is LLM-as-judge, which uses your OpenAI API key. If you installed Ollama and want to try Granite Guardian, toggle the grounding mode using the UI button.
+!!! warning "Don't toggle to Guardian without installing it"
+    The default grounding mode is LLM-as-judge, which uses your OpenAI API key. The **Grounding** toggle in the UI will switch to Guardian mode, but the agent will error if you haven't completed the [optional Ollama setup](prerequisites.md#ollama-granite-guardian). Only toggle if you installed Ollama, pulled the model, and ran `uv sync --extra guardian`.
 
 Select a patient and click **Run Agent**. The agent will take longer than Lab 2 — it's running the full loop (primary agent → grounding → critic → possibly revise).
 
@@ -307,8 +307,8 @@ The critic sees the concerns plus grounding verdicts and decides: approve or rev
 
 ## Step 5: Toggle Grounding Modes
 
-???+ tip "Granite Guardian requires Ollama"
-    The default mode is **LLM-as-judge**, which works with your existing OpenAI API key. To try Granite Guardian, you need Ollama running with the model pulled (see [Prerequisites](prerequisites.md#ollama-granite-guardian)).
+!!! warning "Granite Guardian requires Ollama"
+    The default mode is **LLM-as-judge**, which works with your existing OpenAI API key. To try Granite Guardian, you need Ollama running, the model pulled, and the optional dependency installed — see [Prerequisites](prerequisites.md#ollama-granite-guardian). **Do not toggle to Guardian mode unless you completed those steps**, or the agent will error.
 
 The **Grounding** button at the bottom of the UI toggles between `LLM` and `GUARDIAN` modes. This follows the same pattern as Lab 2's PII masking toggle — a runtime flag on the agent API:
 

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -133,47 +133,64 @@ Focused tools reduce noise, but the agent can still hallucinate and go off-task.
 
 The naive approach is to use the same LLM to evaluate its own output (LLM-as-judge). The problem: the LLM has the same biases and failure modes when judging as when generating. It's checking its own homework.
 
-Lab 3 addresses this with a **two-part evaluation loop**:
+Lab 3 addresses this with a **three-part evaluation loop**:
 
-1. **Grounding check** — verifies that evidence strings are supported by tool output data
-2. **Critic** — evaluates whether the agent stayed on task
+1. **Claim extraction** — an LLM reads each concern and extracts specific, verifiable medical claims
+2. **Grounding check** — each extracted claim is verified against the raw tool output
+3. **Critic** — evaluates whether the agent stayed on task and the grounding results are acceptable
 
-Both run inside a loop with the primary agent:
+All three run inside a loop with the primary agent:
 
 ```mermaid
 graph LR
-    A[Primary Agent] --> B[Grounding Check]
-    B --> C[Critic]
-    C -->|revisions needed| A
-    C -->|approved| D[Save Results]
+    A[Primary Agent] --> B[Extract Claims]
+    B --> C[Grounding Check]
+    C --> D[Critic]
+    D -->|revisions needed| A
+    D -->|approved| E[Save Results]
 ```
+
+### Claim extraction
+
+The agent's output contains a mix of specific facts ("TSH 4.8 mIU/L on 2026-04-01") and vague descriptions ("recent lab results"). A vague description will trivially pass any grounding check — you can't verify something that doesn't assert anything specific.
+
+Before grounding, an LLM reads each concern's summary, action, and evidence fields and extracts every specific medical claim that can actually be checked:
+
+```python
+@observe(name="Claim Extraction")
+def _extract_claims(title, summary, action, evidence) -> list[str]:
+    llm = ChatOpenAI(model=model).with_structured_output(ExtractedClaims)
+    return llm.invoke(_EXTRACT_PROMPT.format(...)).claims
+```
+
+The extraction prompt filters out internal IDs (like `msg-002-003`) and vague references — claims must be self-contained factual assertions that a grounding model can evaluate without looking anything up.
 
 ### The grounding module
 
-Open `lab3/agent/grounding.py`. It has one job: given evidence claims and source data, determine which claims are supported.
-
-Two implementations behind a toggle:
+Open `lab3/agent/grounding.py`. It takes the extracted claims and the tool output, and determines which claims are supported. Two implementations behind a toggle:
 
 ```python
 # "llm" = LLM-as-judge (default), "guardian" = Granite Guardian via Ollama
 grounding_mode: str = "llm"
 ```
 
-The **LLM-as-judge** path sends the evidence and source data to the same OpenAI model:
+The **LLM-as-judge** path sends the claims and tool output to the same OpenAI model:
 
 ```python
-def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+@observe(name="Grounding: LLM-as-Judge")
+def _check_llm_judge(claims: list[str], context: str) -> list[ClaimVerdict]:
     llm = ChatOpenAI(model=model).with_structured_output(...)
-    result = llm.invoke(_JUDGE_PROMPT.format(context=context, evidence=...))
+    result = llm.invoke(_JUDGE_PROMPT.format(context=context, claims=...))
     return result.verdicts
 ```
 
-The **Granite Guardian** path uses a purpose-built model via Ollama. It uses Guardian's canonical message format — the system message selects the `groundedness` risk detector, and the user message provides context and claim:
+The **Granite Guardian** path uses a purpose-built model via Ollama. It uses Guardian's canonical message format — the system message selects the `groundedness` risk detector, and the user message provides the tool output as context and each claim to verify:
 
 ```python
-def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+@observe(name="Grounding: Granite Guardian")
+def _check_guardian(claims: list[str], context: str) -> list[ClaimVerdict]:
     client = ollama.Client(host=OLLAMA_BASE_URL)
-    for claim in evidence:
+    for claim in claims:
         response = client.chat(model=GUARDIAN_MODEL, messages=[
             {"role": "system", "content": "groundedness"},
             {"role": "user", "content": f"Context: {context}\n\nClaim: {claim}"},
@@ -182,6 +199,9 @@ def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
 ```
 
 Granite Guardian is a [separate model fine-tuned specifically for groundedness detection](https://www.ibm.com/granite/docs/models/guardian/). It avoids the self-evaluation problem — a different model with different training checks the work. See the [Granite Guardian cookbook](https://github.com/ibm-granite/granite-guardian/tree/main/cookbooks) for more usage examples.
+
+???+ question "Why not skip claim extraction and check the whole concern at once?"
+    Guardian evaluates **one claim** against **one context** and returns a binary Yes/No. It can't tell you *which part* of a multi-sentence concern is hallucinated. By extracting individual claims first, we get a verdict per assertion — "TSH 4.8" is grounded, but "patient reported dizziness" is not. The critic can then give targeted revision feedback.
 
 ### The critic module
 
@@ -271,17 +291,19 @@ This is the LangGraph ReAct agent — the same structure as Lab 2, but now with 
 - **What keywords did it search for?** The agent had to decide what was relevant. Compare this to Lab 2, where it got everything at once.
 - **How many tokens?** Check the token count. Focused tools mean less data in context, lower cost.
 
-### The "Claim Extraction" and "Grounding Check" spans
+### The "Grounding Check" spans
 
-Grounding happens in two steps. First, a **Claim Extraction** span — an LLM reads the concern's summary, action, and evidence fields and extracts every specific medical claim that can be verified: "Patient's HbA1c is 8.2%", "TSH trending from 3.1 to 4.8", etc. Vague descriptions like "recent message about X" get filtered out — they'd trivially pass any grounding check.
+There's one **Grounding Check** span per concern. Expand it and you'll see two nested steps:
 
-Then the **Grounding Check** spans (one per concern) verify each extracted claim against the raw tool output. Look inside:
+1. **Claim Extraction** — an LLM reads the concern's summary, action, and evidence fields and extracts every specific medical claim that can be verified: "Patient's HbA1c is 8.2%", "TSH trending from 3.1 to 4.8", etc. Vague descriptions like "recent message about X" get filtered out — they'd trivially pass any grounding check.
+
+2. **Grounding: LLM-as-Judge** or **Grounding: Granite Guardian** (depending on the active mode) — each extracted claim is verified against the raw tool output.
+
+Look inside:
 
 - **Input:** The extracted claims, plus the tool call results (the source of truth).
 - **Output:** A verdict per claim — `supported: true/false` with a reason.
 - **Did it catch anything?** If the agent hallucinated a lab value or date, you'll see `supported: false` here.
-
-The span will be labeled **"Grounding: LLM-as-Judge"** or **"Grounding: Granite Guardian"** depending on the active mode.
 
 ### The "Critic Evaluation" span
 

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -30,26 +30,10 @@ This is the inner loop of the ADLC's Operations & Governance phase — monitor, 
 By the end of this lab, you will:
 
 - [x] Know how to use Langfuse traces to identify concrete agent failures
-- [ ] Replace dump-everything tools with keyword-based search tools
-- [ ] Add a critic agent that evaluates the primary agent's output in a loop
-- [ ] Implement hallucination detection using Granite Guardian
-- [ ] Compare LLM-as-judge vs. purpose-built grounding models
-
----
-
-## Prerequisites (optional)
-
-Granite Guardian grounding is **optional** — the lab works out of the box with LLM-as-judge grounding. If you want to compare both approaches, install Ollama:
-
-1. Install [Ollama](https://ollama.com/)
-2. Pull the Granite Guardian model:
-
-```bash
-ollama pull ibm/granite3.2-guardian:3b
-```
-
-???+ tip "Why Ollama?"
-    Granite Guardian runs locally — no API keys, no cloud dependency. Your patient data never leaves your machine, which matters when you're building hallucination detection for healthcare data.
+- [x] Replace dump-everything tools with keyword-based search tools
+- [x] Add a critic agent that evaluates the primary agent's output in a loop
+- [x] Implement hallucination detection using Granite Guardian
+- [x] Compare LLM-as-judge vs. purpose-built grounding models
 
 ---
 
@@ -324,7 +308,7 @@ The critic sees the concerns plus grounding verdicts and decides: approve or rev
 ## Step 5: Toggle Grounding Modes
 
 ???+ tip "Granite Guardian requires Ollama"
-    The default mode is **LLM-as-judge**, which works with your existing OpenAI API key. To try Granite Guardian, you need Ollama running with the model pulled (see [Prerequisites](#prerequisites-optional)).
+    The default mode is **LLM-as-judge**, which works with your existing OpenAI API key. To try Granite Guardian, you need Ollama running with the model pulled (see [Prerequisites](prerequisites.md#ollama-granite-guardian)).
 
 The **Grounding** button at the bottom of the UI toggles between `LLM` and `GUARDIAN` modes. This follows the same pattern as Lab 2's PII masking toggle — a runtime flag on the agent API:
 

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -35,9 +35,9 @@ By the end of this lab, you will:
 
 ---
 
-## Prerequisites
+## Prerequisites (optional)
 
-This lab requires **Ollama** for running Granite Guardian locally.
+Granite Guardian grounding is **optional** — the lab works out of the box with LLM-as-judge grounding. If you want to compare both approaches, install Ollama:
 
 1. Install [Ollama](https://ollama.com/)
 2. Pull the Granite Guardian model:
@@ -153,8 +153,8 @@ Open `lab3/agent/grounding.py`. It has one job: given evidence claims and source
 Two implementations behind a toggle:
 
 ```python
-# "llm" = LLM-as-judge, "guardian" = Granite Guardian via Ollama
-grounding_mode: str = "guardian"
+# "llm" = LLM-as-judge (default), "guardian" = Granite Guardian via Ollama
+grounding_mode: str = "llm"
 ```
 
 The **LLM-as-judge** path sends the evidence and source data to the same OpenAI model:
@@ -166,17 +166,20 @@ def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]
     return result.verdicts
 ```
 
-The **Granite Guardian** path uses a purpose-built model via Ollama:
+The **Granite Guardian** path uses a purpose-built model via Ollama. It uses Guardian's canonical message format — the system message selects the `groundedness` risk detector, and the user message provides context and claim:
 
 ```python
 def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
     client = ollama.Client(host=OLLAMA_BASE_URL)
     for claim in evidence:
-        response = client.chat(model=GUARDIAN_MODEL, messages=[...])
-        # Guardian outputs Yes (hallucination) or No (grounded)
+        response = client.chat(model=GUARDIAN_MODEL, messages=[
+            {"role": "system", "content": "groundedness"},
+            {"role": "user", "content": f"Context: {context}\n\nClaim: {claim}"},
+        ])
+        # Guardian outputs Yes (risk = hallucination) or No (grounded)
 ```
 
-Granite Guardian is a separate model fine-tuned specifically for groundedness detection. It avoids the self-evaluation problem — a different model with different training checks the work.
+Granite Guardian is a [separate model fine-tuned specifically for groundedness detection](https://www.ibm.com/granite/docs/models/guardian/). It avoids the self-evaluation problem — a different model with different training checks the work. See the [Granite Guardian cookbook](https://github.com/ibm-granite/granite-guardian/tree/main/cookbooks) for more usage examples.
 
 ### The critic module
 
@@ -233,34 +236,61 @@ uv run streamlit run app/ui.py --server.port 8501
 uv run uvicorn lab3.agent.api:app --port 8001
 ```
 
-???+ tip "Make sure Ollama is running"
-    The default grounding mode is Granite Guardian, which needs Ollama. Start Ollama before running the agent, or toggle to LLM-as-judge mode using the UI button.
+???+ tip "Ollama is optional"
+    The default grounding mode is LLM-as-judge, which uses your OpenAI API key. If you installed Ollama and want to try Granite Guardian, toggle the grounding mode using the UI button.
 
 Select a patient and click **Run Agent**. The agent will take longer than Lab 2 — it's running the full loop (primary agent → grounding → critic → possibly revise).
 
 ---
 
-## Step 4: Compare in Langfuse
+## Step 4: Read the Trace in Langfuse
 
-Open Langfuse at [http://localhost:3000](http://localhost:3000) and look at the new trace. You'll see more spans than in Lab 2:
+Open Langfuse at [http://localhost:3000](http://localhost:3000) and find the new trace. Each component is a **named span** — a labeled block in the trace timeline that shows what ran, what it received, and what it produced.
 
-- **Primary agent** spans (tool calls + reasoning)
-- **Grounding check** spans (one per concern)
-- **Critic** span (evaluation + feedback)
-- If revisions happened: a second round of all three
+Here's what to look for, top to bottom:
 
-???+ question "Compare traces"
-    Run the agent with both grounding modes and compare the traces:
+### The "Patient Review" span (outermost)
 
-    1. Run with **Granite Guardian** (default)
-    2. Toggle to **LLM** mode using the button at the bottom of the UI
-    3. Run again on the same patient
+This is the full agent run. Expand it to see the three inner components.
 
-    Look at the grounding check spans. How do the two modes differ? Does one catch hallucinations the other misses? What's the latency difference?
+### The "Primary Agent" span
+
+This is the LangGraph ReAct agent — the same structure as Lab 2, but now with **focused search tools**. Look at the tool calls:
+
+- **What tools did it call?** You should see `search_conditions`, `search_labs`, `search_medications` — not `get_patient_record`.
+- **What keywords did it search for?** The agent had to decide what was relevant. Compare this to Lab 2, where it got everything at once.
+- **How many tokens?** Check the token count. Focused tools mean less data in context, lower cost.
+
+### The "Grounding Check" spans (one per concern)
+
+Each concern's evidence gets checked against the tool output. Look inside:
+
+- **Input:** The evidence strings the agent claimed, plus the raw tool output.
+- **Output:** A verdict per evidence string — `supported: true/false` with a reason.
+- **Did it catch anything?** If the agent hallucinated a lab value or date, you'll see `supported: false` here.
+
+The span will be labeled **"Grounding: LLM-as-Judge"** or **"Grounding: Granite Guardian"** depending on the active mode.
+
+### The "Critic Evaluation" span
+
+The critic sees the concerns plus grounding verdicts and decides: approve or revise?
+
+- **Input:** The full concerns JSON plus grounding results.
+- **Output:** Per-concern feedback (on-task? grounded? revision needed?) and an overall `approved: true/false`.
+- **If approved:** The loop ends here. One pass.
+- **If not approved:** Look for a second "Primary Agent" span — the agent re-ran with the critic's feedback injected into the prompt.
+
+???+ question "Things to notice"
+    1. How many revision rounds happened? Was the first attempt good enough, or did the critic catch something?
+    2. Look at the revision feedback — what did the critic flag? Compare the first and second "Primary Agent" outputs.
+    3. Check the grounding verdicts — are there evidence strings marked `supported: false`? Do they match real hallucinations when you compare against the tool output?
 
 ---
 
 ## Step 5: Toggle Grounding Modes
+
+???+ tip "Granite Guardian requires Ollama"
+    The default mode is **LLM-as-judge**, which works with your existing OpenAI API key. To try Granite Guardian, you need Ollama running with the model pulled (see [Prerequisites](#prerequisites-optional)).
 
 The **Grounding** button at the bottom of the UI toggles between `LLM` and `GUARDIAN` modes. This follows the same pattern as Lab 2's PII masking toggle — a runtime flag on the agent API:
 
@@ -275,13 +305,13 @@ def toggle_grounding():
 
 Try both modes on the same patient and compare the results in Langfuse. The key tradeoff:
 
-| | LLM-as-Judge | Granite Guardian |
+| | LLM-as-Judge | [Granite Guardian](https://www.ibm.com/granite/docs/models/guardian/) |
 |---|---|---|
-| **Model** | Same OpenAI model | Purpose-built IBM model |
+| **Model** | Same OpenAI model | [Purpose-built IBM model](https://github.com/ibm-granite/granite-guardian) |
 | **Self-evaluation bias** | Yes — checking its own work | No — separate model |
 | **Cost** | Uses your OpenAI API quota | Free (local via Ollama) |
 | **Latency** | Fast (API call) | Depends on hardware |
-| **Accuracy** | Good at reasoning, prone to bias | Trained for this specific task |
+| **Accuracy** | Good at reasoning, prone to bias | [Trained for this specific task](https://huggingface.co/ibm-granite/granite-guardian-3.1-8b) |
 
 ---
 
@@ -293,7 +323,7 @@ Three targeted improvements, driven by what we found in the traces:
 
 **The critic loop catches problems.** Hallucinated evidence and off-task behavior get flagged and revised. You can see the revision feedback in the traces — the agent's second attempt is typically better than its first.
 
-**Granite Guardian provides independent grounding.** A separate model checking the agent's evidence avoids the self-evaluation problem. You can compare both approaches in the traces and see the difference.
+**Granite Guardian provides independent grounding.** A separate model checking the agent's evidence avoids the self-evaluation problem. You can compare both approaches in the traces — each is a named span ("Grounding: LLM-as-Judge" vs. "Grounding: Granite Guardian") so you can see exactly what each one did.
 
 ---
 

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -7,9 +7,11 @@
 
 ---
 
-## The Improvement Cycle
+## Where We Are in the ADLC
 
-Agent development is iterative. The cycle looks like this:
+The AI Development Lifecycle (ADLC) from the slides describes five phases: **Problem Definition → Data Collection → Model Development → Deployment → Operations & Governance**. Agent-based systems add dimensions at every phase — tool access, autonomy level, memory, and observability.
+
+Lab 1 was **Model Development** — building the agent. Lab 2 was **Operations** — adding observability so you can see what the agent does. Lab 3 is the feedback loop between the two: use what you observe to improve what you build.
 
 ```mermaid
 graph LR
@@ -19,7 +21,7 @@ graph LR
     D --> A
 ```
 
-Lab 2 gave you the **inspect** step. Lab 3 gives you the **fix** step.
+This is the inner loop of the ADLC's Operations & Governance phase — monitor, detect issues, fix, redeploy. Lab 2 gave you the **inspect** step. Lab 3 gives you the **fix** step.
 
 ---
 
@@ -43,7 +45,7 @@ Granite Guardian grounding is **optional** — the lab works out of the box with
 2. Pull the Granite Guardian model:
 
 ```bash
-ollama pull ibm/granite3.2-guardian
+ollama pull ibm/granite3.2-guardian:3b
 ```
 
 ???+ tip "Why Ollama?"
@@ -198,26 +200,34 @@ The critic returns structured feedback per concern — what's wrong and how to f
 
 ### Wiring it together
 
-Open `lab3/agent/agent.py`. The `process_patient` function runs the loop:
+Open `lab3/agent/agent.py`. The loop is a LangGraph `StateGraph` — the same framework as the primary agent, now orchestrating the full review cycle:
 
 ```python
-for revision in range(MAX_REVISIONS):
-    grounding_results = [
-        check_grounding(c.title, c.evidence, context)
-        for c in structured.concerns
-    ]
-    critic_result = critic_evaluate(concerns_json, grounding_results)
+class ReviewState(TypedDict):
+    patient_id: str
+    concerns: PatientConcerns | None
+    tool_context: str
+    revision_feedback: str
+    revision_count: int
+    approved: bool
 
-    if critic_result.approved:
-        break
+graph = StateGraph(ReviewState)
+graph.add_node("primary_agent", primary_agent_node)
+graph.add_node("evaluate", grounding_node)
 
-    # Re-run primary agent with revision feedback
-    structured, context = _run_primary_agent(
-        patient_id, revision_feedback="\n".join(feedback_parts)
-    )
+graph.add_edge(START, "primary_agent")
+graph.add_edge("primary_agent", "evaluate")
+graph.add_conditional_edges("evaluate", should_revise, {
+    "revise": "primary_agent",
+    "done": END,
+})
 ```
 
-Each module has one job. The grounding module doesn't know about the critic. The critic doesn't know about tools. The agent module wires them together. When you read one file, you understand one thing.
+The `primary_agent` node runs the ReAct agent. The `evaluate` node runs grounding checks and the critic. The conditional edge `should_revise` routes back to the primary agent if the critic requests revision, or to `END` if approved (or max revisions reached).
+
+State flows through the graph as a `ReviewState` dict — no manual variable juggling, no bookkeeping bugs. LangGraph handles the loop, the state threading, and the conditional routing.
+
+Each module has one job. The grounding module doesn't know about the critic. The critic doesn't know about tools. The graph wires them together. When you read one file, you understand one thing.
 
 ---
 
@@ -261,12 +271,14 @@ This is the LangGraph ReAct agent — the same structure as Lab 2, but now with 
 - **What keywords did it search for?** The agent had to decide what was relevant. Compare this to Lab 2, where it got everything at once.
 - **How many tokens?** Check the token count. Focused tools mean less data in context, lower cost.
 
-### The "Grounding Check" spans (one per concern)
+### The "Claim Extraction" and "Grounding Check" spans
 
-Each concern's evidence gets checked against the tool output. Look inside:
+Grounding happens in two steps. First, a **Claim Extraction** span — an LLM reads the concern's summary, action, and evidence fields and extracts every specific medical claim that can be verified: "Patient's HbA1c is 8.2%", "TSH trending from 3.1 to 4.8", etc. Vague descriptions like "recent message about X" get filtered out — they'd trivially pass any grounding check.
 
-- **Input:** The evidence strings the agent claimed, plus the raw tool output.
-- **Output:** A verdict per evidence string — `supported: true/false` with a reason.
+Then the **Grounding Check** spans (one per concern) verify each extracted claim against the raw tool output. Look inside:
+
+- **Input:** The extracted claims, plus the tool call results (the source of truth).
+- **Output:** A verdict per claim — `supported: true/false` with a reason.
 - **Did it catch anything?** If the agent hallucinated a lab value or date, you'll see `supported: false` here.
 
 The span will be labeled **"Grounding: LLM-as-Judge"** or **"Grounding: Granite Guardian"** depending on the active mode.

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -95,6 +95,28 @@ docker compose version
     docker compose -f docker-compose.langfuse.yml pull
     ```
 
+## Optional for Lab 3
+
+### Ollama + Granite Guardian
+
+Lab 3 includes a grounding check that compares LLM-as-judge vs. [Granite Guardian](https://www.ibm.com/granite/docs/models/guardian/). The Guardian path is **optional** — the lab works out of the box with LLM-as-judge grounding. If you want to compare both approaches:
+
+1. Install [Ollama](https://ollama.com/)
+2. Pull the Granite Guardian model (the `:3b` tag is required — the model has no default tag):
+
+```bash
+ollama pull ibm/granite3.2-guardian:3b
+```
+
+Verify it's working:
+
+```bash
+ollama list | grep guardian
+```
+
+???+ tip "Why Ollama?"
+    Granite Guardian runs locally — no API keys, no cloud dependency. Your patient data never leaves your machine, which matters when you're building hallucination detection for healthcare data.
+
 ---
 
 ## Clone and Install

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -108,11 +108,20 @@ Lab 3 includes a grounding check that compares LLM-as-judge vs. [Granite Guardia
 ollama pull ibm/granite3.2-guardian:3b
 ```
 
-Verify it's working:
+3. Install the optional Python dependency:
+
+```bash
+uv sync --extra guardian
+```
+
+Verify Ollama has the model:
 
 ```bash
 ollama list | grep guardian
 ```
+
+!!! warning "Don't toggle without installing"
+    The **Grounding** toggle in Lab 3's UI will switch to Guardian mode, but the agent will crash if `ollama` isn't installed or the model isn't pulled. Only flip the toggle if you completed these steps.
 
 ???+ tip "Why Ollama?"
     Granite Guardian runs locally — no API keys, no cloud dependency. Your patient data never leaves your machine, which matters when you're building hallucination detection for healthcare data.

--- a/lab3/agent/__init__.py
+++ b/lab3/agent/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+API_URL = os.environ.get("API_URL", "http://localhost:8000")

--- a/lab3/agent/agent.py
+++ b/lab3/agent/agent.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
 from langchain_openai import ChatOpenAI
 from langfuse import observe
@@ -98,8 +98,10 @@ _react_agent = create_react_agent(
     response_format=PatientConcerns,
 )
 
-# Initialize Langfuse with PII masking on import (side effect sets up the singleton).
-_langfuse_handler = create_langfuse_handler()
+# Initialize the Langfuse singleton with PII masking on import.
+# The returned handler isn't used directly — each node creates its own —
+# but this call registers the mask function on the global Langfuse client.
+create_langfuse_handler()
 
 
 def _extract_tool_context(messages: list) -> str:

--- a/lab3/agent/agent.py
+++ b/lab3/agent/agent.py
@@ -1,0 +1,175 @@
+"""
+The improved agent — a primary agent + critic loop with grounding checks.
+
+What changed from Lab 2:
+- Focused search tools instead of get_patient_record (see tools.py)
+- Grounding check verifies evidence against tool output (see grounding.py)
+- Critic evaluates on-task behavior and grounding (see critic.py)
+- All three run in a loop: agent → grounding → critic → revise → repeat
+
+The loop continues until the critic approves or MAX_REVISIONS is reached.
+The full back-and-forth is visible in Langfuse traces.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+from lab3.agent.tools import ALL_TOOLS
+from lab3.agent.models import PatientConcerns
+from lab3.agent.observability import create_langfuse_handler
+from lab3.agent.grounding import check_grounding, GroundingResult
+from lab3.agent.critic import evaluate as critic_evaluate
+
+logger = logging.getLogger(__name__)
+
+MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
+MAX_REVISIONS = int(os.environ.get("MAX_REVISIONS", "2"))
+
+SYSTEM_PROMPT = """\
+You are a clinical inbox assistant for a primary care practice. You review a
+patient's record and portal messages, then surface actionable concerns for the
+doctor. Think of yourself as a resident pre-rounding: your job is to organize
+what the attending needs to see, not to make decisions.
+
+A "concern" is anything that needs the doctor's attention:
+- A patient message that hasn't been answered
+- An abnormal or trending lab value
+- A medication issue (expiring refill, reported side effect)
+- An overdue follow-up or screening
+- A symptom the patient reports
+- An administrative request (scheduling, referral, records)
+
+HOW TO INVESTIGATE:
+Use the available tools to explore the patient's record. You decide what to
+look at and in what order. Check labs, encounters, medications — whatever is
+relevant to the concerns you find. Gather evidence before concluding.
+
+OUTPUT RULES:
+- "summary" must be ONE sentence. State the clinical fact, not a paragraph.
+  Good: "TSH trending up from 3.1 to 4.8 over 6 months with new resting HR increase."
+  Bad: "The patient has been experiencing a gradual increase in TSH levels..."
+- "action" must say what the DOCTOR needs to do. Be specific.
+  Good: "Reply to portal message — patient is requesting levothyroxine trial"
+  Good: "Review TSH trend and correlate with HR increase at next visit"
+  Bad: "Monitor" or "Follow up"
+- "evidence" should be specific values and dates, not descriptions.
+  Good: "TSH 4.8 mIU/L (2026-04-01), up from 3.1 (2025-06-18)"
+  Bad: "Patient has elevated TSH"
+- "related" MUST include the specific message_ids, lab_dates, conditions, and
+  encounter_dates that are relevant. These become links in the UI.
+- Only surface information that is IN the record. Do not infer diagnoses.
+- Do not draft replies or make clinical recommendations.
+"""
+
+
+def _build_agent():
+    """Build the LangGraph ReAct agent with focused search tools."""
+    llm = ChatOpenAI(model=MODEL)
+    return create_react_agent(
+        model=llm,
+        tools=ALL_TOOLS,
+        prompt=SYSTEM_PROMPT,
+        response_format=PatientConcerns,
+    )
+
+
+_agent = _build_agent()
+_langfuse_handler = create_langfuse_handler()
+
+
+def _extract_tool_context(messages: list) -> str:
+    """Extract tool call results from the agent's message history.
+
+    This becomes the source-of-truth context for grounding checks —
+    did the agent's evidence actually come from these tool outputs?
+    """
+    chunks = []
+    for msg in messages:
+        if hasattr(msg, "type") and msg.type == "tool":
+            chunks.append(str(msg.content))
+    return "\n---\n".join(chunks)
+
+
+def _run_primary_agent(patient_id: str, revision_feedback: str = "") -> tuple[PatientConcerns, str]:
+    """Run the primary agent, optionally with revision feedback from the critic."""
+    user_message = (
+        f"Please review patient {patient_id}. "
+        "Start by looking at their messages and record, then investigate "
+        "any concerns you find. When done, output your findings."
+    )
+    if revision_feedback:
+        user_message += (
+            "\n\nREVISION REQUESTED — a reviewer found issues with your "
+            "previous output. Fix them:\n" + revision_feedback
+        )
+
+    result = _agent.invoke(
+        {"messages": [{"role": "user", "content": user_message}]},
+        config={
+            "callbacks": [_langfuse_handler],
+            "metadata": {
+                "langfuse_session_id": f"patient-review-{patient_id}",
+                "langfuse_tags": ["lab3", patient_id],
+            },
+        },
+    )
+
+    structured = result["structured_response"]
+    context = _extract_tool_context(result["messages"])
+    return structured, context
+
+
+def process_patient(patient_id: str) -> PatientConcerns:
+    """Run the agent loop: primary agent → grounding → critic → revise.
+
+    The loop continues until the critic approves or MAX_REVISIONS is reached.
+    """
+    logger.info("[%s] Starting agent run", patient_id)
+
+    structured, context = _run_primary_agent(patient_id)
+
+    for revision in range(MAX_REVISIONS):
+        # Grounding: check each concern's evidence against tool output
+        grounding_results: list[GroundingResult] = []
+        for concern in structured.concerns:
+            result = check_grounding(concern.title, concern.evidence, context)
+            grounding_results.append(result)
+
+        # Critic: evaluate on-task behavior + grounding
+        concerns_json = json.dumps(
+            [c.model_dump() for c in structured.concerns], indent=2
+        )
+        critic_result = critic_evaluate(concerns_json, grounding_results)
+
+        if critic_result.approved:
+            logger.info("[%s] Critic approved after %d revision(s)", patient_id, revision)
+            break
+
+        # Build revision feedback and re-run
+        logger.info("[%s] Critic requested revision %d: %s", patient_id, revision + 1, critic_result.summary)
+        feedback_parts = [critic_result.summary]
+        for fb in critic_result.concern_feedback:
+            if fb.revision_needed:
+                feedback_parts.append(f"- {fb.concern_title}: {fb.feedback}")
+        structured, context = _run_primary_agent(
+            patient_id, revision_feedback="\n".join(feedback_parts)
+        )
+    else:
+        logger.warning("[%s] Max revisions reached, using last output", patient_id)
+
+    # Normalize patient_id and timestamps
+    now = datetime.now(timezone.utc).isoformat()
+    for concern in structured.concerns:
+        concern.patient_id = patient_id
+        if not concern.last_updated:
+            concern.last_updated = now
+    if not structured.patient_id:
+        structured.patient_id = patient_id
+
+    logger.info("[%s] Final: %d concerns", patient_id, len(structured.concerns))
+    return structured

--- a/lab3/agent/agent.py
+++ b/lab3/agent/agent.py
@@ -5,9 +5,9 @@ What changed from Lab 2:
 - Focused search tools instead of get_patient_record (see tools.py)
 - Grounding check verifies evidence against tool output (see grounding.py)
 - Critic evaluates on-task behavior and grounding (see critic.py)
-- All three run in a loop: agent → grounding → critic → revise → repeat
+- All three are nodes in a LangGraph StateGraph that loops until approved
 
-The loop continues until the critic approves or MAX_REVISIONS is reached.
+The graph: primary_agent → grounding → critic →(revise?)→ primary_agent
 The full back-and-forth is visible in Langfuse traces.
 """
 
@@ -15,10 +15,12 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from typing import Annotated, TypedDict
 
 from langchain_openai import ChatOpenAI
 from langfuse import observe
 from langfuse.langchain import CallbackHandler
+from langgraph.graph import StateGraph, START, END
 from langgraph.prebuilt import create_react_agent
 
 from lab3.agent.tools import ALL_TOOLS
@@ -69,27 +71,42 @@ OUTPUT RULES:
 """
 
 
-def _build_agent():
-    """Build the LangGraph ReAct agent with focused search tools."""
-    llm = ChatOpenAI(model=MODEL)
-    return create_react_agent(
-        model=llm,
-        tools=ALL_TOOLS,
-        prompt=SYSTEM_PROMPT,
-        response_format=PatientConcerns,
-    )
+# --- State schema ---
 
 
-_agent = _build_agent()
+class ReviewState(TypedDict):
+    """State that flows through the review graph.
+
+    Each node receives the full state and returns a partial dict of updates.
+    LangGraph merges the updates into the state before the next node runs.
+    """
+    patient_id: str                  # Which patient we're reviewing
+    concerns: PatientConcerns | None # The primary agent's structured output
+    tool_context: str                # Raw tool call results (grounding source-of-truth)
+    revision_feedback: str           # Critic feedback for the next revision pass
+    revision_count: int              # How many revision loops we've completed
+    approved: bool                   # Whether the critic approved the output
+
+
+# --- Graph nodes ---
+
+
+_react_agent = create_react_agent(
+    model=ChatOpenAI(model=MODEL, max_retries=3),
+    tools=ALL_TOOLS,
+    prompt=SYSTEM_PROMPT,
+    response_format=PatientConcerns,
+)
 
 # Initialize Langfuse with PII masking on import (side effect sets up the singleton).
 _langfuse_handler = create_langfuse_handler()
 
 
 def _extract_tool_context(messages: list) -> str:
-    """Extract tool call results from the agent's message history.
+    """Extract tool call results from the ReAct agent's LangGraph message history.
 
-    This becomes the source-of-truth context for grounding checks —
+    Filters for ToolMessage objects (the raw data each tool returned) and
+    joins them. This becomes the source-of-truth for grounding checks —
     did the agent's evidence actually come from these tool outputs?
     """
     chunks = []
@@ -100,75 +117,143 @@ def _extract_tool_context(messages: list) -> str:
 
 
 @observe(name="Primary Agent")
-def _run_primary_agent(patient_id: str, revision_feedback: str = "") -> tuple[PatientConcerns, str]:
-    """Run the primary agent, optionally with revision feedback from the critic."""
+def primary_agent_node(state: ReviewState) -> dict:
+    """Run the ReAct agent to generate or revise concerns.
+
+    On the first pass, the agent investigates the patient record from scratch.
+    On revision passes, the critic's feedback is appended to the prompt so
+    the agent knows what to fix. Returns updated concerns and the raw tool
+    output that the grounding check will verify against.
+    """
     user_message = (
-        f"Please review patient {patient_id}. "
+        f"Please review patient {state['patient_id']}. "
         "Start by looking at their messages and record, then investigate "
         "any concerns you find. When done, output your findings."
     )
-    if revision_feedback:
+    if state["revision_feedback"]:
         user_message += (
             "\n\nREVISION REQUESTED — a reviewer found issues with your "
-            "previous output. Fix them:\n" + revision_feedback
+            "previous output. Fix them:\n" + state["revision_feedback"]
         )
 
-    # CallbackHandler() auto-nests under the current @observe span.
     handler = CallbackHandler()
-    result = _agent.invoke(
+    result = _react_agent.invoke(
         {"messages": [{"role": "user", "content": user_message}]},
         config={
             "callbacks": [handler],
             "metadata": {
-                "langfuse_session_id": f"patient-review-{patient_id}",
-                "langfuse_tags": ["lab3", patient_id],
+                "langfuse_session_id": f"patient-review-{state['patient_id']}",
+                "langfuse_tags": ["lab3", state["patient_id"]],
             },
         },
     )
 
-    structured = result["structured_response"]
-    context = _extract_tool_context(result["messages"])
-    return structured, context
+    return {
+        "concerns": result["structured_response"],
+        "tool_context": _extract_tool_context(result["messages"]),
+    }
+
+
+def grounding_node(state: ReviewState) -> dict:
+    """Run grounding checks and the critic in sequence.
+
+    First, an LLM extracts specific medical claims from each concern
+    (summary, action, evidence). Then each claim is verified against
+    the raw tool output. Finally the critic evaluates whether concerns
+    are on-task and grounded. If approved, sets approved=True.
+    Otherwise, builds revision feedback for the next pass.
+    """
+    grounding_results: list[GroundingResult] = []
+    for concern in state["concerns"].concerns:
+        result = check_grounding(concern, state["tool_context"])
+        grounding_results.append(result)
+
+    concerns_json = json.dumps(
+        [c.model_dump() for c in state["concerns"].concerns], indent=2
+    )
+    critic_result = critic_evaluate(concerns_json, grounding_results)
+
+    if critic_result.approved:
+        logger.info("[%s] Critic approved on revision %d",
+                    state["patient_id"], state["revision_count"])
+        return {"approved": True}
+
+    # Build revision feedback for the next primary agent pass
+    logger.info("[%s] Critic requested revision %d: %s",
+                state["patient_id"], state["revision_count"] + 1,
+                critic_result.summary)
+    feedback_parts = [critic_result.summary]
+    for fb in critic_result.concern_feedback:
+        if fb.revision_needed:
+            feedback_parts.append(f"- {fb.concern_title}: {fb.feedback}")
+
+    return {
+        "approved": False,
+        "revision_feedback": "\n".join(feedback_parts),
+        "revision_count": state["revision_count"] + 1,
+    }
+
+
+def should_revise(state: ReviewState) -> str:
+    """Conditional edge: route back to the primary agent or finish.
+
+    Returns "done" if the critic approved or we've hit MAX_REVISIONS.
+    Returns "revise" to send the agent through another pass with feedback.
+    """
+    if state["approved"]:
+        return "done"
+    if state["revision_count"] >= MAX_REVISIONS:
+        logger.warning("[%s] Max revisions reached, using last output", state["patient_id"])
+        return "done"
+    return "revise"
+
+
+# --- Build the graph ---
+
+
+def _build_review_graph():
+    """Build the review graph: primary_agent → evaluate → (revise or done)."""
+    graph = StateGraph(ReviewState)
+
+    graph.add_node("primary_agent", primary_agent_node)
+    graph.add_edge(START, "primary_agent")
+
+    graph.add_node("evaluate", grounding_node)
+    graph.add_edge("primary_agent", "evaluate")
+
+    graph.add_conditional_edges("evaluate", should_revise, {
+        "revise": "primary_agent",
+        "done": END,
+    })
+
+    return graph.compile()
+
+
+_review_graph = _build_review_graph()
+
+
+# --- Public API ---
 
 
 @observe(name="Patient Review")
 def process_patient(patient_id: str) -> PatientConcerns:
-    """Run the agent loop: primary agent → grounding → critic → revise.
+    """Entry point: run the full review graph for a patient.
 
-    The loop continues until the critic approves or MAX_REVISIONS is reached.
+    Invokes the compiled graph with initial state, then normalizes the
+    output (fills in patient_id, timestamps) before returning.
     """
     logger.info("[%s] Starting agent run", patient_id)
 
-    structured, context = _run_primary_agent(patient_id)
+    result = _review_graph.invoke({
+        "patient_id": patient_id,
+        "concerns": None,
+        "tool_context": "",
+        "revision_feedback": "",
+        "revision_count": 0,
+        "approved": False,
+    })
 
-    for revision in range(MAX_REVISIONS):
-        # Grounding: check each concern's evidence against tool output
-        grounding_results: list[GroundingResult] = []
-        for concern in structured.concerns:
-            result = check_grounding(concern.title, concern.evidence, context)
-            grounding_results.append(result)
-
-        # Critic: evaluate on-task behavior + grounding
-        concerns_json = json.dumps(
-            [c.model_dump() for c in structured.concerns], indent=2
-        )
-        critic_result = critic_evaluate(concerns_json, grounding_results)
-
-        if critic_result.approved:
-            logger.info("[%s] Critic approved after %d revision(s)", patient_id, revision)
-            break
-
-        # Build revision feedback and re-run
-        logger.info("[%s] Critic requested revision %d: %s", patient_id, revision + 1, critic_result.summary)
-        feedback_parts = [critic_result.summary]
-        for fb in critic_result.concern_feedback:
-            if fb.revision_needed:
-                feedback_parts.append(f"- {fb.concern_title}: {fb.feedback}")
-        structured, context = _run_primary_agent(
-            patient_id, revision_feedback="\n".join(feedback_parts)
-        )
-    else:
-        logger.warning("[%s] Max revisions reached, using last output", patient_id)
+    structured = result["concerns"]
 
     # Normalize patient_id and timestamps
     now = datetime.now(timezone.utc).isoformat()

--- a/lab3/agent/agent.py
+++ b/lab3/agent/agent.py
@@ -17,6 +17,8 @@ import os
 from datetime import datetime, timezone
 
 from langchain_openai import ChatOpenAI
+from langfuse import observe
+from langfuse.langchain import CallbackHandler
 from langgraph.prebuilt import create_react_agent
 
 from lab3.agent.tools import ALL_TOOLS
@@ -79,6 +81,8 @@ def _build_agent():
 
 
 _agent = _build_agent()
+
+# Initialize Langfuse with PII masking on import (side effect sets up the singleton).
 _langfuse_handler = create_langfuse_handler()
 
 
@@ -95,6 +99,7 @@ def _extract_tool_context(messages: list) -> str:
     return "\n---\n".join(chunks)
 
 
+@observe(name="Primary Agent")
 def _run_primary_agent(patient_id: str, revision_feedback: str = "") -> tuple[PatientConcerns, str]:
     """Run the primary agent, optionally with revision feedback from the critic."""
     user_message = (
@@ -108,10 +113,12 @@ def _run_primary_agent(patient_id: str, revision_feedback: str = "") -> tuple[Pa
             "previous output. Fix them:\n" + revision_feedback
         )
 
+    # CallbackHandler() auto-nests under the current @observe span.
+    handler = CallbackHandler()
     result = _agent.invoke(
         {"messages": [{"role": "user", "content": user_message}]},
         config={
-            "callbacks": [_langfuse_handler],
+            "callbacks": [handler],
             "metadata": {
                 "langfuse_session_id": f"patient-review-{patient_id}",
                 "langfuse_tags": ["lab3", patient_id],
@@ -124,6 +131,7 @@ def _run_primary_agent(patient_id: str, revision_feedback: str = "") -> tuple[Pa
     return structured, context
 
 
+@observe(name="Patient Review")
 def process_patient(patient_id: str) -> PatientConcerns:
     """Run the agent loop: primary agent → grounding → critic → revise.
 

--- a/lab3/agent/api.py
+++ b/lab3/agent/api.py
@@ -1,0 +1,105 @@
+"""
+Agent API — serves concerns from the agent's store.
+
+This is the agent's side of the contract. The main API proxies
+/patients/{id}/concerns here. Each lab can reimplement this API
+however it wants, as long as it serves the same Concern schema.
+
+Run with: uv run uvicorn lab3.agent.api:app --port 8001
+"""
+
+import threading
+from fastapi import FastAPI, HTTPException
+
+from lab3.agent.models import Concern
+from lab3.agent.store import get_concerns, load_store, resolve_concern
+
+app = FastAPI(title="Lab 3 Agent API", version="0.1.0")
+
+_run_lock = threading.Lock()
+_run_error: str | None = None
+
+
+@app.get("/patients/{patient_id}/concerns", response_model=list[Concern])
+def patient_concerns(patient_id: str):
+    """Get concerns for a patient from the agent store."""
+    return get_concerns(patient_id)
+
+
+@app.get("/status")
+def agent_status():
+    """Check when the agent last ran and whether it's currently running."""
+    store = load_store()
+    total = sum(len(pc.concerns) for pc in store.patients.values())
+    return {
+        "last_run": store.last_run,
+        "patient_count": len(store.patients),
+        "total_concerns": total,
+        "running": _run_lock.locked(),
+        "error": _run_error,
+    }
+
+
+@app.post("/patients/{patient_id}/run")
+def trigger_run(patient_id: str):
+    """Run the agent for a single patient in a background thread."""
+    if _run_lock.locked():
+        return {"status": "already_running"}
+
+    def _background_run():
+        global _run_error
+        from lab3.agent.run import run_single
+        with _run_lock:
+            _run_error = None
+            try:
+                run_single(patient_id)
+            except Exception as e:
+                _run_error = str(e)
+
+    thread = threading.Thread(target=_background_run, daemon=True)
+    thread.start()
+    return {"status": "started", "patient_id": patient_id}
+
+
+@app.post("/patients/{patient_id}/concerns/{concern_id}/resolve")
+def mark_resolved(patient_id: str, concern_id: str):
+    """Mark a concern as resolved."""
+    if not resolve_concern(patient_id, concern_id):
+        raise HTTPException(status_code=404, detail="Concern not found")
+    return {"status": "resolved"}
+
+
+# --- Masking toggle ---
+# Lets participants compare masked vs. unmasked traces without restarting.
+
+@app.get("/masking")
+def get_masking():
+    """Check whether PII masking is currently enabled."""
+    from lab3.agent.observability.masking import masking_enabled
+    return {"enabled": masking_enabled}
+
+
+@app.post("/masking/toggle")
+def toggle_masking():
+    """Toggle PII masking on/off. Takes effect on the next agent run."""
+    import lab3.agent.observability.masking as m
+    m.masking_enabled = not m.masking_enabled
+    return {"enabled": m.masking_enabled}
+
+
+# --- Grounding mode toggle ---
+# Lets participants compare LLM-as-judge vs. Granite Guardian grounding.
+
+@app.get("/grounding")
+def get_grounding():
+    """Check which grounding mode is active: 'llm' or 'guardian'."""
+    from lab3.agent.grounding import grounding_mode
+    return {"mode": grounding_mode}
+
+
+@app.post("/grounding/toggle")
+def toggle_grounding():
+    """Toggle grounding mode between LLM-as-judge and Granite Guardian."""
+    import lab3.agent.grounding as g
+    g.grounding_mode = "llm" if g.grounding_mode == "guardian" else "guardian"
+    return {"mode": g.grounding_mode}

--- a/lab3/agent/api.py
+++ b/lab3/agent/api.py
@@ -43,18 +43,21 @@ def agent_status():
 @app.post("/patients/{patient_id}/run")
 def trigger_run(patient_id: str):
     """Run the agent for a single patient in a background thread."""
-    if _run_lock.locked():
+    # Acquire non-blocking to avoid TOCTOU race — if two requests arrive
+    # simultaneously, only the one that gets the lock proceeds.
+    if not _run_lock.acquire(blocking=False):
         return {"status": "already_running"}
 
     def _background_run():
         global _run_error
         from lab3.agent.run import run_single
-        with _run_lock:
+        try:
             _run_error = None
-            try:
-                run_single(patient_id)
-            except Exception as e:
-                _run_error = str(e)
+            run_single(patient_id)
+        except Exception as e:
+            _run_error = str(e)
+        finally:
+            _run_lock.release()
 
     thread = threading.Thread(target=_background_run, daemon=True)
     thread.start()

--- a/lab3/agent/critic.py
+++ b/lab3/agent/critic.py
@@ -20,7 +20,7 @@ from langfuse import observe
 from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
 
-from lab3.agent.grounding import GroundingResult
+from lab3.agent.grounding import GroundingResult, ClaimVerdict
 
 logger = logging.getLogger(__name__)
 
@@ -73,17 +73,29 @@ GROUNDING RESULTS:
 
 @observe(name="Critic Evaluation")
 def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> CriticResult:
-    """Run the critic on the primary agent's output."""
+    """Run the critic on the primary agent's output.
+
+    On failure (rate limits, timeouts), approves the output as-is —
+    better to surface unreviewed concerns than to crash the run.
+    """
     model = os.environ.get("OPENAI_MODEL", "gpt-4o")
-    llm = ChatOpenAI(model=model).with_structured_output(CriticResult)
+    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(CriticResult)
 
     grounding_json = "\n".join(r.model_dump_json() for r in grounding_results)
 
-    handler = CallbackHandler()
-    return llm.invoke(
-        _CRITIC_PROMPT.format(
-            concerns=concerns_json,
-            grounding=grounding_json or "(no grounding results)",
-        ),
-        config={"callbacks": [handler]},
-    )
+    try:
+        handler = CallbackHandler()
+        return llm.invoke(
+            _CRITIC_PROMPT.format(
+                concerns=concerns_json,
+                grounding=grounding_json or "(no grounding results)",
+            ),
+            config={"callbacks": [handler]},
+        )
+    except Exception:
+        logger.warning("Critic evaluation failed, auto-approving", exc_info=True)
+        return CriticResult(
+            concern_feedback=[],
+            approved=True,
+            summary="Critic unavailable — output accepted without review.",
+        )

--- a/lab3/agent/critic.py
+++ b/lab3/agent/critic.py
@@ -20,7 +20,7 @@ from langfuse import observe
 from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
 
-from lab3.agent.grounding import GroundingResult, ClaimVerdict
+from lab3.agent.grounding import GroundingResult
 
 logger = logging.getLogger(__name__)
 

--- a/lab3/agent/critic.py
+++ b/lab3/agent/critic.py
@@ -16,6 +16,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+from langfuse import observe
+from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
 
 from lab3.agent.grounding import GroundingResult
@@ -69,6 +71,7 @@ GROUNDING RESULTS:
 """
 
 
+@observe(name="Critic Evaluation")
 def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> CriticResult:
     """Run the critic on the primary agent's output."""
     model = os.environ.get("OPENAI_MODEL", "gpt-4o")
@@ -76,7 +79,11 @@ def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> Cr
 
     grounding_json = "\n".join(r.model_dump_json() for r in grounding_results)
 
-    return llm.invoke(_CRITIC_PROMPT.format(
-        concerns=concerns_json,
-        grounding=grounding_json or "(no grounding results)",
-    ))
+    handler = CallbackHandler()
+    return llm.invoke(
+        _CRITIC_PROMPT.format(
+            concerns=concerns_json,
+            grounding=grounding_json or "(no grounding results)",
+        ),
+        config={"callbacks": [handler]},
+    )

--- a/lab3/agent/critic.py
+++ b/lab3/agent/critic.py
@@ -1,0 +1,82 @@
+"""
+Critic — evaluates whether the agent stayed on task.
+
+The critic receives the primary agent's concerns plus grounding results
+and checks two things:
+  1. Is each concern on-task? (Surfacing actionable items for the doctor,
+     not making diagnoses or drafting replies.)
+  2. Are the grounding results acceptable? (Incorporates verdicts from
+     the grounding check module.)
+
+Returns structured feedback that the primary agent uses to revise its output.
+This is a single LLM call with structured output — not a tool-calling agent.
+"""
+
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel
+
+from lab3.agent.grounding import GroundingResult
+
+logger = logging.getLogger(__name__)
+
+
+# --- Structured output ---
+
+
+class ConcernFeedback(BaseModel):
+    """Feedback for a single concern."""
+    concern_title: str
+    on_task: bool
+    grounded: bool
+    revision_needed: bool
+    feedback: str
+
+
+class CriticResult(BaseModel):
+    """The critic's evaluation of all concerns."""
+    concern_feedback: list[ConcernFeedback]
+    approved: bool
+    summary: str
+
+
+# --- Critic prompt ---
+
+
+_CRITIC_PROMPT = """\
+You are a quality reviewer for a clinical inbox assistant. The assistant reviews
+patient records and surfaces concerns for the doctor. Your job is to evaluate
+whether each concern meets the quality bar.
+
+For each concern, check:
+1. ON-TASK: Is this surfacing an actionable item for the doctor? Flag concerns
+   that make diagnoses, draft replies, give clinical recommendations, or go
+   beyond what's in the record.
+2. GROUNDED: The grounding check results are provided. If evidence was flagged
+   as unsupported, the concern needs revision.
+3. EVIDENCE QUALITY: Are the evidence strings specific (values, dates, names)
+   rather than vague descriptions?
+
+Set approved=true ONLY if every concern passes all checks.
+
+CONCERNS:
+{concerns}
+
+GROUNDING RESULTS:
+{grounding}
+"""
+
+
+def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> CriticResult:
+    """Run the critic on the primary agent's output."""
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
+    llm = ChatOpenAI(model=model).with_structured_output(CriticResult)
+
+    grounding_json = "\n".join(r.model_dump_json() for r in grounding_results)
+
+    return llm.invoke(_CRITIC_PROMPT.format(
+        concerns=concerns_json,
+        grounding=grounding_json or "(no grounding results)",
+    ))

--- a/lab3/agent/grounding.py
+++ b/lab3/agent/grounding.py
@@ -49,6 +49,11 @@ class ClaimVerdict(BaseModel):
     reason: str
 
 
+class ClaimVerdicts(BaseModel):
+    """Wrapper for structured output — list of grounding verdicts."""
+    verdicts: list[ClaimVerdict]
+
+
 class GroundingResult(BaseModel):
     """Grounding results for one concern."""
     concern_title: str
@@ -140,11 +145,7 @@ CLAIMS TO VERIFY:
 def _check_llm_judge(claims: list[str], context: str) -> list[ClaimVerdict]:
     """Use the same OpenAI model to evaluate groundedness."""
     model = os.environ.get("OPENAI_MODEL", "gpt-4o")
-    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(
-        type("ClaimVerdicts", (BaseModel,), {
-            "__annotations__": {"verdicts": list[ClaimVerdict]},
-        })
-    )
+    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(ClaimVerdicts)
     handler = CallbackHandler()
     result = llm.invoke(
         _JUDGE_PROMPT.format(context=context, claims=json.dumps(claims)),

--- a/lab3/agent/grounding.py
+++ b/lab3/agent/grounding.py
@@ -17,6 +17,8 @@ import logging
 import os
 
 from langchain_openai import ChatOpenAI
+from langfuse import observe
+from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -24,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # --- Runtime toggle ---
 # "llm" = LLM-as-judge, "guardian" = Granite Guardian via Ollama
-grounding_mode: str = "guardian"
+grounding_mode: str = "llm"
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 GUARDIAN_MODEL = os.environ.get("GUARDIAN_MODEL", "ibm/granite3.2-guardian")
@@ -68,6 +70,7 @@ EVIDENCE CLAIMS:
 """
 
 
+@observe(name="Grounding: LLM-as-Judge")
 def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]:
     """Use the same OpenAI model to evaluate groundedness."""
     model = os.environ.get("OPENAI_MODEL", "gpt-4o")
@@ -76,18 +79,27 @@ def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]
             "__annotations__": {"verdicts": list[EvidenceVerdict]},
         })
     )
-    result = llm.invoke(_JUDGE_PROMPT.format(
-        context=context,
-        evidence=json.dumps(evidence),
-    ))
+    handler = CallbackHandler()
+    result = llm.invoke(
+        _JUDGE_PROMPT.format(context=context, evidence=json.dumps(evidence)),
+        config={"callbacks": [handler]},
+    )
     return result.verdicts
 
 
 # --- Granite Guardian implementation ---
 
 
+@observe(name="Grounding: Granite Guardian")
 def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
-    """Use Granite Guardian via Ollama for groundedness detection."""
+    """Use Granite Guardian via Ollama for groundedness detection.
+
+    Uses the canonical Granite Guardian message format:
+    - system: "groundedness" (selects the groundedness risk detector)
+    - user: "Context: ...\n\nClaim: ..." (the evidence to verify)
+
+    Guardian outputs Yes (risk detected = hallucination) or No (grounded).
+    """
     import ollama
 
     client = ollama.Client(host=OLLAMA_BASE_URL)
@@ -97,20 +109,19 @@ def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
         response = client.chat(
             model=GUARDIAN_MODEL,
             messages=[
+                {"role": "system", "content": "groundedness"},
                 {
                     "role": "user",
-                    "content": (
-                        f"Check if the following claim is supported by the context.\n\n"
-                        f"Context: {context}\n\n"
-                        f"Claim: {claim}"
-                    ),
+                    "content": f"Context: {context}\n\nClaim: {claim}",
                 },
             ],
             options={"temperature": 0.0},
         )
         text = response["message"]["content"]
-        # Granite Guardian outputs Yes (risk = hallucination) or No (grounded)
-        is_hallucinated = "yes" in text.lower().split("</think>")[-1].lower()
+        # Guardian outputs "Yes" (risk = hallucination) or "No" (grounded).
+        # Strip any <think> reasoning tags if present.
+        answer = text.split("</think>")[-1].strip().lower()
+        is_hallucinated = "yes" in answer
         verdicts.append(EvidenceVerdict(
             evidence=claim,
             supported=not is_hallucinated,
@@ -123,6 +134,7 @@ def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
 # --- Public API ---
 
 
+@observe(name="Grounding Check")
 def check_grounding(concern_title: str, evidence: list[str], context: str) -> GroundingResult:
     """Check whether evidence claims are grounded in source data.
 

--- a/lab3/agent/grounding.py
+++ b/lab3/agent/grounding.py
@@ -1,0 +1,143 @@
+"""
+Grounding check — verify that the agent's evidence is real, not hallucinated.
+
+Two implementations behind a runtime toggle:
+  1. LLM-as-judge: the same OpenAI model evaluates whether each concern's
+     evidence is supported by the tool output. Convenient but circular —
+     the LLM is checking its own work.
+  2. Granite Guardian: a purpose-built IBM model for groundedness detection,
+     served locally via Ollama. A separate model avoids self-evaluation bias.
+
+The toggle follows the same pattern as Lab 2's PII masking toggle:
+a module-level flag flipped by the agent API at runtime.
+"""
+
+import json
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# --- Runtime toggle ---
+# "llm" = LLM-as-judge, "guardian" = Granite Guardian via Ollama
+grounding_mode: str = "guardian"
+
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+GUARDIAN_MODEL = os.environ.get("GUARDIAN_MODEL", "ibm/granite3.2-guardian")
+
+
+# --- Structured output for grounding verdicts ---
+
+
+class EvidenceVerdict(BaseModel):
+    """Grounding verdict for a single piece of evidence."""
+    evidence: str
+    supported: bool
+    reason: str
+
+
+class GroundingResult(BaseModel):
+    """Grounding results for one concern."""
+    concern_title: str
+    verdicts: list[EvidenceVerdict]
+    all_supported: bool
+
+
+# --- LLM-as-judge implementation ---
+
+
+_JUDGE_PROMPT = """\
+You are a grounding evaluator. Given source data from tool calls and a list of
+evidence claims from an agent, determine whether each claim is supported by the
+source data.
+
+For each evidence string, output:
+- supported: true if the claim matches the source data (values, dates, names)
+- supported: false if the claim contains information not in the source data
+- reason: brief explanation
+
+SOURCE DATA:
+{context}
+
+EVIDENCE CLAIMS:
+{evidence}
+"""
+
+
+def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+    """Use the same OpenAI model to evaluate groundedness."""
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
+    llm = ChatOpenAI(model=model).with_structured_output(
+        type("EvidenceVerdicts", (BaseModel,), {
+            "__annotations__": {"verdicts": list[EvidenceVerdict]},
+        })
+    )
+    result = llm.invoke(_JUDGE_PROMPT.format(
+        context=context,
+        evidence=json.dumps(evidence),
+    ))
+    return result.verdicts
+
+
+# --- Granite Guardian implementation ---
+
+
+def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+    """Use Granite Guardian via Ollama for groundedness detection."""
+    import ollama
+
+    client = ollama.Client(host=OLLAMA_BASE_URL)
+    verdicts = []
+
+    for claim in evidence:
+        response = client.chat(
+            model=GUARDIAN_MODEL,
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        f"Check if the following claim is supported by the context.\n\n"
+                        f"Context: {context}\n\n"
+                        f"Claim: {claim}"
+                    ),
+                },
+            ],
+            options={"temperature": 0.0},
+        )
+        text = response["message"]["content"]
+        # Granite Guardian outputs Yes (risk = hallucination) or No (grounded)
+        is_hallucinated = "yes" in text.lower().split("</think>")[-1].lower()
+        verdicts.append(EvidenceVerdict(
+            evidence=claim,
+            supported=not is_hallucinated,
+            reason=text.strip(),
+        ))
+
+    return verdicts
+
+
+# --- Public API ---
+
+
+def check_grounding(concern_title: str, evidence: list[str], context: str) -> GroundingResult:
+    """Check whether evidence claims are grounded in source data.
+
+    Uses the current grounding_mode to select the implementation.
+    """
+    if not evidence:
+        return GroundingResult(concern_title=concern_title, verdicts=[], all_supported=True)
+
+    if grounding_mode == "guardian":
+        verdicts = _check_guardian(evidence, context)
+    else:
+        verdicts = _check_llm_judge(evidence, context)
+
+    return GroundingResult(
+        concern_title=concern_title,
+        verdicts=verdicts,
+        all_supported=all(v.supported for v in verdicts),
+    )

--- a/lab3/agent/grounding.py
+++ b/lab3/agent/grounding.py
@@ -1,12 +1,14 @@
 """
-Grounding check — verify that the agent's evidence is real, not hallucinated.
+Grounding check — verify that the agent's output is real, not hallucinated.
 
-Two implementations behind a runtime toggle:
-  1. LLM-as-judge: the same OpenAI model evaluates whether each concern's
-     evidence is supported by the tool output. Convenient but circular —
-     the LLM is checking its own work.
-  2. Granite Guardian: a purpose-built IBM model for groundedness detection,
-     served locally via Ollama. A separate model avoids self-evaluation bias.
+Three steps:
+  1. Claim extraction: an LLM reads the concern (summary, action, evidence)
+     and extracts every specific medical claim that needs verification.
+  2. Grounding: each extracted claim is checked against the tool output.
+     Two implementations behind a runtime toggle:
+       a. LLM-as-judge: the same OpenAI model evaluates groundedness.
+       b. Granite Guardian: a purpose-built IBM model via Ollama.
+  3. Results are returned to the caller (the evaluate node) for the critic.
 
 The toggle follows the same pattern as Lab 2's PII masking toggle:
 a module-level flag flipped by the agent API at runtime.
@@ -29,15 +31,20 @@ logger = logging.getLogger(__name__)
 grounding_mode: str = "llm"
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
-GUARDIAN_MODEL = os.environ.get("GUARDIAN_MODEL", "ibm/granite3.2-guardian")
+GUARDIAN_MODEL = os.environ.get("GUARDIAN_MODEL", "ibm/granite3.2-guardian:3b")
 
 
-# --- Structured output for grounding verdicts ---
+# --- Structured output ---
 
 
-class EvidenceVerdict(BaseModel):
-    """Grounding verdict for a single piece of evidence."""
-    evidence: str
+class ExtractedClaims(BaseModel):
+    """Medical claims extracted from a concern for grounding verification."""
+    claims: list[str]
+
+
+class ClaimVerdict(BaseModel):
+    """Grounding verdict for a single claim."""
+    claim: str
     supported: bool
     reason: str
 
@@ -45,8 +52,67 @@ class EvidenceVerdict(BaseModel):
 class GroundingResult(BaseModel):
     """Grounding results for one concern."""
     concern_title: str
-    verdicts: list[EvidenceVerdict]
+    claims: list[str]
+    verdicts: list[ClaimVerdict]
     all_supported: bool
+
+
+# --- Claim extraction ---
+
+
+_EXTRACT_PROMPT = """\
+You are a medical claim extractor. Given a concern from a clinical inbox
+assistant, extract every specific medical claim that can be verified against
+source data.
+
+A claim is a self-contained factual assertion about the patient — a diagnosis,
+a lab value, a medication, a date, a symptom, a message content. Each claim
+must be understandable on its own without looking anything up.
+
+RULES:
+- Do NOT include internal IDs (message IDs, encounter IDs, patient IDs).
+  Replace them with the actual content they refer to.
+- Do NOT include vague descriptions like "recent message about X" or
+  "previous encounters."
+- Each claim must contain the specific fact being asserted.
+
+Good claims:
+- "Patient's HbA1c is 8.2%"
+- "Patient was prescribed metformin 500mg"
+- "Patient reported blurry vision in a portal message dated 2026-04-15"
+- "TSH trending up from 3.1 to 4.8 over 6 months"
+- "Patient expressed anxiety about pending MRI results on 2026-04-24"
+
+Bad claims (do not extract):
+- "Recent lab results"
+- "Messages from August"
+- "Patient awaiting MRI results: msg-002-003"
+- "See encounter enc-005"
+
+CONCERN:
+Title: {title}
+Summary: {summary}
+Action: {action}
+Evidence: {evidence}
+"""
+
+
+@observe(name="Claim Extraction")
+def _extract_claims(title: str, summary: str, action: str, evidence: list[str]) -> list[str]:
+    """Extract specific, verifiable medical claims from a concern."""
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
+    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(ExtractedClaims)
+    handler = CallbackHandler()
+    result = llm.invoke(
+        _EXTRACT_PROMPT.format(
+            title=title,
+            summary=summary,
+            action=action or "(none)",
+            evidence="\n".join(f"- {e}" for e in evidence) if evidence else "(none)",
+        ),
+        config={"callbacks": [handler]},
+    )
+    return result.claims
 
 
 # --- LLM-as-judge implementation ---
@@ -54,34 +120,34 @@ class GroundingResult(BaseModel):
 
 _JUDGE_PROMPT = """\
 You are a grounding evaluator. Given source data from tool calls and a list of
-evidence claims from an agent, determine whether each claim is supported by the
+medical claims from an agent, determine whether each claim is supported by the
 source data.
 
-For each evidence string, output:
+For each claim, output:
 - supported: true if the claim matches the source data (values, dates, names)
 - supported: false if the claim contains information not in the source data
 - reason: brief explanation
 
-SOURCE DATA:
+SOURCE DATA (tool call results):
 {context}
 
-EVIDENCE CLAIMS:
-{evidence}
+CLAIMS TO VERIFY:
+{claims}
 """
 
 
 @observe(name="Grounding: LLM-as-Judge")
-def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+def _check_llm_judge(claims: list[str], context: str) -> list[ClaimVerdict]:
     """Use the same OpenAI model to evaluate groundedness."""
     model = os.environ.get("OPENAI_MODEL", "gpt-4o")
-    llm = ChatOpenAI(model=model).with_structured_output(
-        type("EvidenceVerdicts", (BaseModel,), {
-            "__annotations__": {"verdicts": list[EvidenceVerdict]},
+    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(
+        type("ClaimVerdicts", (BaseModel,), {
+            "__annotations__": {"verdicts": list[ClaimVerdict]},
         })
     )
     handler = CallbackHandler()
     result = llm.invoke(
-        _JUDGE_PROMPT.format(context=context, evidence=json.dumps(evidence)),
+        _JUDGE_PROMPT.format(context=context, claims=json.dumps(claims)),
         config={"callbacks": [handler]},
     )
     return result.verdicts
@@ -91,12 +157,12 @@ def _check_llm_judge(evidence: list[str], context: str) -> list[EvidenceVerdict]
 
 
 @observe(name="Grounding: Granite Guardian")
-def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
+def _check_guardian(claims: list[str], context: str) -> list[ClaimVerdict]:
     """Use Granite Guardian via Ollama for groundedness detection.
 
     Uses the canonical Granite Guardian message format:
     - system: "groundedness" (selects the groundedness risk detector)
-    - user: "Context: ...\n\nClaim: ..." (the evidence to verify)
+    - user: "Context: ...\n\nClaim: ..." (the claim to verify)
 
     Guardian outputs Yes (risk detected = hallucination) or No (grounded).
     """
@@ -105,7 +171,7 @@ def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
     client = ollama.Client(host=OLLAMA_BASE_URL)
     verdicts = []
 
-    for claim in evidence:
+    for claim in claims:
         response = client.chat(
             model=GUARDIAN_MODEL,
             messages=[
@@ -122,8 +188,8 @@ def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
         # Strip any <think> reasoning tags if present.
         answer = text.split("</think>")[-1].strip().lower()
         is_hallucinated = "yes" in answer
-        verdicts.append(EvidenceVerdict(
-            evidence=claim,
+        verdicts.append(ClaimVerdict(
+            claim=claim,
             supported=not is_hallucinated,
             reason=text.strip(),
         ))
@@ -135,21 +201,48 @@ def _check_guardian(evidence: list[str], context: str) -> list[EvidenceVerdict]:
 
 
 @observe(name="Grounding Check")
-def check_grounding(concern_title: str, evidence: list[str], context: str) -> GroundingResult:
-    """Check whether evidence claims are grounded in source data.
+def check_grounding(concern, tool_context: str) -> GroundingResult:
+    """Extract medical claims from a concern and verify them against tool output.
 
-    Uses the current grounding_mode to select the implementation.
+    Step 1: An LLM extracts specific, verifiable claims from the concern's
+    summary, action, and evidence fields.
+    Step 2: Each claim is checked against the tool output using the active
+    grounding mode (LLM-as-judge or Granite Guardian).
+
+    On failure (rate limits, timeouts), assumes grounded and lets the
+    original output stand — better to surface an unverified concern
+    than to crash the entire run.
     """
-    if not evidence:
-        return GroundingResult(concern_title=concern_title, verdicts=[], all_supported=True)
+    try:
+        claims = _extract_claims(
+            concern.title, concern.summary, concern.action, concern.evidence
+        )
+    except Exception:
+        logger.warning("Claim extraction failed for '%s', skipping grounding", concern.title, exc_info=True)
+        return GroundingResult(
+            concern_title=concern.title, claims=[], verdicts=[], all_supported=True
+        )
 
-    if grounding_mode == "guardian":
-        verdicts = _check_guardian(evidence, context)
-    else:
-        verdicts = _check_llm_judge(evidence, context)
+    if not claims:
+        return GroundingResult(
+            concern_title=concern.title, claims=[], verdicts=[], all_supported=True
+        )
+
+    try:
+        if grounding_mode == "guardian":
+            verdicts = _check_guardian(claims, tool_context)
+        else:
+            verdicts = _check_llm_judge(claims, tool_context)
+    except Exception:
+        logger.warning("Grounding check failed for '%s', assuming grounded", concern.title, exc_info=True)
+        verdicts = [
+            ClaimVerdict(claim=c, supported=True, reason="grounding check unavailable")
+            for c in claims
+        ]
 
     return GroundingResult(
-        concern_title=concern_title,
+        concern_title=concern.title,
+        claims=claims,
         verdicts=verdicts,
         all_supported=all(v.supported for v in verdicts),
     )

--- a/lab3/agent/models.py
+++ b/lab3/agent/models.py
@@ -1,0 +1,25 @@
+"""
+Shared models — the contract between the main API and the agent API.
+
+Any service that serves or consumes concerns must use these models.
+The main API proxies to the agent API; both sides agree on this schema.
+"""
+
+from pydantic import BaseModel
+
+from app.models import (
+    Concern, ConcernType, ConcernStatus, Urgency, RelatedData, _pii,
+)
+
+
+class PatientConcerns(BaseModel):
+    """All concerns for one patient."""
+    patient_id: str
+    patient_name: str = _pii()
+    concerns: list[Concern] = []
+
+
+class ConcernsStore(BaseModel):
+    """The full agent output — all patients' concerns. Written as a flat JSON file."""
+    patients: dict[str, PatientConcerns] = {}
+    last_run: str = ""

--- a/lab3/agent/observability/__init__.py
+++ b/lab3/agent/observability/__init__.py
@@ -1,0 +1,11 @@
+"""
+Observability utilities for Lab 3.
+
+This module provides:
+- PII masking for Langfuse traces (masking.py)
+- A helper to create a pre-configured Langfuse callback handler
+"""
+
+from lab3.agent.observability.masking import mask_pii, create_langfuse_handler
+
+__all__ = ["mask_pii", "create_langfuse_handler"]

--- a/lab3/agent/observability/masking.py
+++ b/lab3/agent/observability/masking.py
@@ -1,0 +1,192 @@
+"""
+PII masking for Langfuse traces using LangChain's Presidio integration.
+
+This module provides the `mask_pii` function that Langfuse applies to all
+trace data (inputs, outputs, metadata) *before* it leaves the process.
+This is client-side masking — the strongest guarantee that sensitive data
+never reaches your trace store.
+
+Two layers of defense:
+1. Field-level redaction: Pydantic models annotated with sensitivity="pii"
+   or sensitivity="phi" are redacted by field name — no NER needed.
+2. NER-based detection (Presidio via spaCy): catches PII embedded in free-text
+   fields where you can't predict the key name.
+
+Presidio is the most widely adopted open-source PII detection library
+(~4M monthly PyPI downloads, first-class LangChain integration).
+"""
+
+import logging
+import os
+
+from langchain_experimental.data_anonymizer import PresidioAnonymizer
+from presidio_analyzer import Pattern, PatternRecognizer
+from presidio_anonymizer.entities import OperatorConfig
+from langfuse.langchain import CallbackHandler
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# --- Pydantic model introspection ---
+
+def _get_sensitive_fields(model_class: type[BaseModel]) -> dict[str, str]:
+    """Extract fields annotated with sensitivity metadata from a Pydantic model.
+
+    Returns a dict mapping field name -> sensitivity level ("pii" or "phi").
+    """
+    sensitive = {}
+    for name, field_info in model_class.model_fields.items():
+        extra = field_info.json_schema_extra
+        if isinstance(extra, dict) and "sensitivity" in extra:
+            sensitive[name] = extra["sensitivity"]
+    return sensitive
+
+
+# Cache to avoid re-inspecting the same model class repeatedly.
+_sensitive_fields_cache: dict[type, dict[str, str]] = {}
+
+
+def _sensitive_fields_for(model_class: type[BaseModel]) -> dict[str, str]:
+    if model_class not in _sensitive_fields_cache:
+        _sensitive_fields_cache[model_class] = _get_sensitive_fields(model_class)
+    return _sensitive_fields_cache[model_class]
+
+
+# --- Build the Presidio anonymizer for free-text fields ---
+
+_ANALYZED_FIELDS = [
+    "PERSON",           # Patient names, doctor names, emergency contacts
+    "EMAIL_ADDRESS",    # Patient email addresses
+    "PHONE_NUMBER",     # Patient and contact phone numbers
+    "US_SSN",           # Social Security Numbers
+    "LOCATION",         # Street addresses, cities, states
+    "DATE_TIME",        # Dates of birth, appointment dates
+    "CREDIT_CARD",      # Unlikely in EHR but good to catch
+    "URL",              # Any URLs in trace data
+]
+
+_anonymizer = PresidioAnonymizer(
+    analyzed_fields=_ANALYZED_FIELDS,
+    add_default_faker_operators=False,
+)
+
+# Custom recognizer: insurance member IDs in our data (e.g., "1EG4-TE5-MK72")
+_anonymizer.add_recognizer(
+    PatternRecognizer(
+        supported_entity="INSURANCE_MEMBER_ID",
+        patterns=[
+            Pattern(
+                name="member_id_alphanum_hyphen",
+                regex=r"\b(?=[A-Z0-9-]*[A-Z])[A-Z0-9]{2,}(?:-[A-Z0-9]{2,}){2,}\b",
+                score=0.7,
+            ),
+        ],
+    )
+)
+_anonymizer.add_operators({
+    "INSURANCE_MEMBER_ID": OperatorConfig("replace", {"new_value": "<INSURANCE_MEMBER_ID>"}),
+})
+
+
+# --- Masking logic ---
+
+_PLACEHOLDER = {
+    "pii": "<PII_REDACTED>",
+    "phi": "<PHI_REDACTED>",
+}
+
+
+def _mask_value(value, _redact_as=None):
+    """Recursively mask PII/PHI in arbitrary data structures.
+
+    Args:
+        value: The data to mask.
+        _redact_as: If set ("pii" or "phi"), this value was identified as
+            sensitive by its parent model's field annotation. Short strings
+            are replaced entirely; long strings still go through Presidio
+            (they may contain a mix of sensitive and non-sensitive content).
+    """
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+
+    if isinstance(value, str):
+        # If the parent model flagged this field as sensitive, redact directly.
+        # This handles short fields like names where NER is unreliable.
+        if _redact_as:
+            return _PLACEHOLDER.get(_redact_as, "<REDACTED>")
+        if not value.strip():
+            return value
+        return _anonymizer.anonymize(value)
+
+    if isinstance(value, dict):
+        return {k: _mask_value(v) for k, v in value.items()}
+
+    if isinstance(value, (list, tuple)):
+        return [_mask_value(item) for item in value]
+
+    # Pydantic models: use field annotations to decide what to redact.
+    if isinstance(value, BaseModel):
+        sensitive = _sensitive_fields_for(type(value))
+        dumped = value.model_dump(by_alias=True)
+        result = {}
+        # Map alias -> field name for sensitivity lookup
+        alias_to_field = {
+            (fi.alias or name): name
+            for name, fi in type(value).model_fields.items()
+        }
+        for key, val in dumped.items():
+            field_name = alias_to_field.get(key, key)
+            sensitivity = sensitive.get(field_name)
+            result[key] = _mask_value(val, _redact_as=sensitivity)
+        return result
+
+    # Unrecognized type — pass through and warn.
+    logger.warning("mask_pii: unhandled type %s, passing through unmasked", type(value).__name__)
+    return value
+
+
+# --- Runtime toggle ---
+# Masking can be enabled/disabled at runtime via the agent API,
+# so participants can compare masked vs. unmasked traces without restarting.
+masking_enabled = False
+
+
+def mask_pii(*, data, **kwargs):
+    """Mask PII in trace data before it's sent to Langfuse.
+
+    This function is passed to the Langfuse client via the `mask` parameter.
+    It is called on every piece of data (inputs, outputs, metadata) before
+    transmission. When masking_enabled is False, data passes through unchanged.
+
+    Args:
+        data: The value to mask — can be a string, dict, list, or other type.
+        **kwargs: Reserved for future Langfuse API extensions.
+
+    Returns:
+        The masked data in the same structure.
+    """
+    if not masking_enabled:
+        return data
+    return _mask_value(data)
+
+
+def create_langfuse_handler(**kwargs) -> CallbackHandler:
+    """Create a Langfuse CallbackHandler with PII masking enabled.
+
+    The handler reads connection details from environment variables:
+        LANGFUSE_PUBLIC_KEY  (default: pk-lf-workshop)
+        LANGFUSE_SECRET_KEY  (default: sk-lf-workshop)
+        LANGFUSE_HOST        (default: http://localhost:3000)
+
+    Any additional kwargs are passed through to CallbackHandler.
+    """
+    from langfuse import Langfuse
+
+    os.environ.setdefault("LANGFUSE_PUBLIC_KEY", "pk-lf-workshop")
+    os.environ.setdefault("LANGFUSE_SECRET_KEY", "sk-lf-workshop")
+    os.environ.setdefault("LANGFUSE_HOST", "http://localhost:3000")
+
+    Langfuse(mask=mask_pii)
+
+    return CallbackHandler(**kwargs)

--- a/lab3/agent/run.py
+++ b/lab3/agent/run.py
@@ -64,7 +64,7 @@ def stores_match(a: ConcernsStore, b: ConcernsStore) -> bool:
 
 def main():
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
-    logger.info("=== Lab 3: Observable Agent ===")
+    logger.info("=== Lab 3: Improved Agent ===")
     logger.info("Starting concern extraction loop...")
 
     previous = load_store()

--- a/lab3/agent/run.py
+++ b/lab3/agent/run.py
@@ -1,0 +1,88 @@
+"""
+Agent entrypoint — run the concern-extraction loop.
+
+Processes all patients, writes concerns to the store, then polls for changes.
+When a pass produces no new or changed concerns, the agent announces DONE.
+
+Usage:
+    uv run python -m lab3.agent.run
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+
+import requests
+
+from lab3.agent import API_URL
+from lab3.agent.agent import process_patient
+from lab3.agent.store import load_store, save_store
+from lab3.agent.models import ConcernsStore
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = 30  # seconds between passes
+
+
+def run_single(patient_id: str):
+    """Run the agent for a single patient and save to the store."""
+    logger.info("Processing %s", patient_id)
+    result = process_patient(patient_id)
+
+    store = load_store()
+    store.patients[patient_id] = result
+    store.last_run = datetime.now(timezone.utc).isoformat()
+    save_store(store)
+
+    n = len(result.concerns)
+    logger.info("  -> %d concern%s identified (saved)", n, "s" if n != 1 else "")
+
+
+def run_pass() -> ConcernsStore:
+    """Run the agent once for every patient. Saves incrementally after each patient."""
+    resp = requests.get(f"{API_URL}/patients")
+    resp.raise_for_status()
+    patients = resp.json()
+
+    for p in patients:
+        run_single(p["id"])
+
+    return load_store()
+
+
+def stores_match(a: ConcernsStore, b: ConcernsStore) -> bool:
+    """Check if two stores have the same concerns (ignoring timestamps)."""
+    if set(a.patients.keys()) != set(b.patients.keys()):
+        return False
+    for pid in a.patients:
+        a_titles = sorted(c.title for c in a.patients[pid].concerns)
+        b_titles = sorted(c.title for c in b.patients[pid].concerns)
+        if a_titles != b_titles:
+            return False
+    return True
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    logger.info("=== Lab 3: Observable Agent ===")
+    logger.info("Starting concern extraction loop...")
+
+    previous = load_store()
+
+    while True:
+        new_store = run_pass()
+
+        total = sum(len(pc.concerns) for pc in new_store.patients.values())
+        logger.info("Pass complete: %d total concerns across %d patients", total, len(new_store.patients))
+
+        if stores_match(previous, new_store):
+            logger.info("DONE — no new concerns found. Agent is up to date.")
+            break
+
+        previous = new_store
+        logger.info("Concerns changed. Polling again in %ds...", POLL_INTERVAL)
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/lab3/agent/store.py
+++ b/lab3/agent/store.py
@@ -1,0 +1,52 @@
+"""
+Naive agent store — a flat JSON file.
+
+This is intentionally unsophisticated: one file, no history, no audit trail.
+The agent overwrites it on every run. Later labs will improve this.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from lab3.agent.models import Concern, ConcernsStore, PatientConcerns
+
+STORE_PATH = Path(os.environ.get("AGENT_STORE", "data/agent_output.json"))
+
+
+def load_store() -> ConcernsStore:
+    """Load the current store from disk. Returns empty store if file doesn't exist."""
+    if not STORE_PATH.exists():
+        return ConcernsStore()
+    with open(STORE_PATH) as f:
+        return ConcernsStore.model_validate(json.load(f))
+
+
+def save_store(store: ConcernsStore):
+    """Write the store to disk, overwriting any previous version."""
+    STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(STORE_PATH, "w") as f:
+        json.dump(store.model_dump(), f, indent=2)
+
+
+def get_concerns(patient_id: str) -> list[Concern]:
+    """Get concerns for a single patient."""
+    store = load_store()
+    patient_concerns = store.patients.get(patient_id)
+    if patient_concerns is None:
+        return []
+    return patient_concerns.concerns
+
+
+def resolve_concern(patient_id: str, concern_id: str) -> bool:
+    """Mark a concern as resolved. Returns True if found and updated."""
+    store = load_store()
+    patient_concerns = store.patients.get(patient_id)
+    if patient_concerns is None:
+        return False
+    for c in patient_concerns.concerns:
+        if c.id == concern_id:
+            c.status = "resolved"
+            save_store(store)
+            return True
+    return False

--- a/lab3/agent/tools.py
+++ b/lab3/agent/tools.py
@@ -1,0 +1,99 @@
+"""
+Agent tools — keyword-based search tools for patient data.
+
+Lab 3 replaces the naive "dump everything" tools from Labs 1–2 with
+focused search tools. The agent must specify *what* it's looking for,
+which forces it to reason about relevance and reduces token waste / PHI
+exposure in traces.
+
+Each tool hits a dedicated search endpoint on the main API.
+"""
+
+import requests
+from langchain_core.tools import tool
+
+from lab3.agent import API_URL
+
+
+@tool
+def list_patients() -> list[dict]:
+    """Get a summary of all patients: IDs, names, birth dates, active conditions."""
+    resp = requests.get(f"{API_URL}/patients")
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def get_demographics(patient_id: str) -> dict:
+    """Get a patient's demographics: name, birth date, contact info, insurance."""
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/demographics")
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def get_messages(patient_id: str) -> list[dict]:
+    """Get all portal messages for a patient, newest first. Includes message body, sender, category, subject, and full thread."""
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/messages")
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def search_conditions(patient_id: str, keyword: str) -> list[dict]:
+    """Search a patient's conditions by keyword (e.g., 'diabetes', 'hypertension').
+
+    Returns matching conditions with status, onset date, and notes.
+    """
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/conditions", params={"q": keyword})
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def search_medications(patient_id: str, keyword: str) -> list[dict]:
+    """Search a patient's medications by keyword (e.g., 'metformin', 'statin').
+
+    Returns matching medications with dosage, frequency, status, and prescriber.
+    """
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/medications", params={"q": keyword})
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def search_labs(patient_id: str, test_name: str) -> list[dict]:
+    """Search for lab results by test name (e.g., 'potassium', 'eGFR', 'hemoglobin').
+
+    Returns matching results sorted newest first with date, value, unit, and interpretation.
+    Useful for tracking trends over time.
+    """
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/labs", params={"test": test_name})
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def search_encounters(patient_id: str, keyword: str) -> list[dict]:
+    """Search a patient's encounters by keyword (e.g., 'follow-up', 'annual', 'urgent').
+
+    Returns matching encounters with date, type, provider, reason, and notes.
+    """
+    resp = requests.get(f"{API_URL}/patients/{patient_id}/encounters", params={"q": keyword})
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tool
+def get_inbox() -> list[dict]:
+    """Get all messages across ALL patients that still need a provider response. Returns patient name, message subject, date, and category."""
+    resp = requests.get(f"{API_URL}/inbox")
+    resp.raise_for_status()
+    return resp.json()
+
+
+ALL_TOOLS = [
+    list_patients, get_demographics, get_messages,
+    search_conditions, search_medications, search_labs, search_encounters,
+    get_inbox,
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,11 @@ dependencies = [
     "langfuse>=2.0",
     "presidio-analyzer>=2.2",
     "presidio-anonymizer>=2.2",
+    "ollama>=0.4",
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["app", "lab1", "lab2"]
+packages = ["app", "lab1", "lab2", "lab3"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ dependencies = [
     "langfuse>=2.0",
     "presidio-analyzer>=2.2",
     "presidio-anonymizer>=2.2",
-    "ollama>=0.4",
 ]
+
+[project.optional-dependencies]
+guardian = ["ollama>=0.4"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["app", "lab1", "lab2", "lab3"]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langfuse" },
     { name = "langgraph" },
+    { name = "ollama" },
     { name = "openai" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
@@ -45,6 +46,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langfuse", specifier = ">=2.0" },
     { name = "langgraph", specifier = ">=0.4" },
+    { name = "ollama", specifier = ">=0.4" },
     { name = "openai", specifier = ">=1.0" },
     { name = "presidio-analyzer", specifier = ">=2.2" },
     { name = "presidio-anonymizer", specifier = ">=2.2" },
@@ -1690,6 +1692,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
     { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
     { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -24,13 +24,17 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langfuse" },
     { name = "langgraph" },
-    { name = "ollama" },
     { name = "openai" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
     { name = "requests" },
     { name = "streamlit" },
     { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+guardian = [
+    { name = "ollama" },
 ]
 
 [package.dev-dependencies]
@@ -46,7 +50,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langfuse", specifier = ">=2.0" },
     { name = "langgraph", specifier = ">=0.4" },
-    { name = "ollama", specifier = ">=0.4" },
+    { name = "ollama", marker = "extra == 'guardian'", specifier = ">=0.4" },
     { name = "openai", specifier = ">=1.0" },
     { name = "presidio-analyzer", specifier = ">=2.2" },
     { name = "presidio-anonymizer", specifier = ">=2.2" },
@@ -54,6 +58,7 @@ requires-dist = [
     { name = "streamlit", specifier = ">=1.45" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
+provides-extras = ["guardian"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## Summary

- **Focused search tools**: Replaced dump-everything `get_patient_record` with keyword-based tools (`search_conditions`, `search_medications`, `search_labs`, `search_encounters`) that force intentional investigation
- **Critic loop**: Primary agent → grounding check → critic evaluation → revise cycle, running until approved or max revisions reached
- **Grounding checks**: Runtime toggle between LLM-as-judge and Granite Guardian (via Ollama) for hallucination detection — participants can compare both approaches
- **Search API endpoints**: Added recursive `_contains` keyword matcher and search endpoints to `app/api.py`
- **UI grounding toggle**: Same pattern as Lab 2's PII masking toggle
- **Full lab documentation**: Complete `docs/content/lab-3.md` with code walkthrough, architecture diagrams, and comparison guidance

## Test plan

- [ ] `uv sync` installs cleanly with new `ollama` dependency
- [ ] `uv run uvicorn app.api:app --port 8000` — search endpoints return filtered results
- [ ] `uv run uvicorn lab3.agent.api:app --port 8001` — agent starts, grounding toggle works
- [ ] Run agent on a patient — verify critic loop visible in Langfuse traces
- [ ] Toggle grounding mode via UI — verify both LLM and Guardian modes produce verdicts
- [ ] `uv run pytest` passes

Fixes #11

---
> 🤖 Generated by **claude** · AI-assisted workflow