### PR TITLE
feat: provider-swappable LLM with free-tier Gemini default

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -4,30 +4,37 @@
 # Copy this file to .env and uncomment the section for your chosen LLM provider.
 # Only ONE provider section should be active at a time.
 #
+# Total LLM cost for the entire workshop should be under $5 on any paid provider.
+#
 # Quick start (Gemini — free, no credit card):
 #   1. Go to https://aistudio.google.com/apikey
-#   2. Create an API key with your Google account
+#   2. Create an API key using the default project
 #   3. Uncomment the Gemini section below and paste your key
 #   4. Install deps: uv sync --extra gemini
 
 # --- LLM Provider (pick one) ------------------------------------------------
 
 # Option 1: Google Gemini (DEFAULT — free tier, no credit card required)
+# Model: gemini-2.5-flash-lite (free, 15 RPM — good for Labs 1-2)
+# Note: Free tier may be too slow for Lab 3+. Switch to a paid provider
+#        or ask your instructor for a shared key.
 LLM_PROVIDER=gemini
+LLM_MODEL=gemini-2.5-flash-lite
 GOOGLE_API_KEY=your-google-api-key-here
 
-# Option 2: OpenAI
+# Option 2: OpenAI (recommended for all labs — ~$0.15/1M input tokens)
+# Model: gpt-4o-mini (fast, cheap, excellent tool calling)
+# Sign up: https://platform.openai.com/
 # LLM_PROVIDER=openai
+# LLM_MODEL=gpt-4o-mini
 # OPENAI_API_KEY=your-openai-api-key-here
 
-# Option 3: Anthropic
+# Option 3: Anthropic (~$1/1M input tokens)
+# Model: claude-haiku-4-5-20251001 (cheapest Claude with tool calling)
+# Sign up: https://console.anthropic.com/
 # LLM_PROVIDER=anthropic
+# LLM_MODEL=claude-haiku-4-5-20251001
 # ANTHROPIC_API_KEY=your-anthropic-api-key-here
-
-# --- Model override (optional) ----------------------------------------------
-# Uncomment to use a specific model instead of the provider's default.
-# Defaults: gemini-2.5-flash, gpt-4o, claude-sonnet-4-20250514
-# LLM_MODEL=gemini-2.5-flash
 
 # --- API URLs ----------------------------------------------------------------
 # API_URL=http://localhost:8000

--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,44 @@
+# =============================================================================
+# AI Agents Workshop — Environment Variables
+# =============================================================================
+# Copy this file to .env and uncomment the section for your chosen LLM provider.
+# Only ONE provider section should be active at a time.
+#
+# Quick start (Gemini — free, no credit card):
+#   1. Go to https://aistudio.google.com/apikey
+#   2. Create an API key with your Google account
+#   3. Uncomment the Gemini section below and paste your key
+#   4. Install deps: uv sync --extra gemini
+
+# --- LLM Provider (pick one) ------------------------------------------------
+
+# Option 1: Google Gemini (DEFAULT — free tier, no credit card required)
+LLM_PROVIDER=gemini
+GOOGLE_API_KEY=your-google-api-key-here
+
+# Option 2: OpenAI
+# LLM_PROVIDER=openai
+# OPENAI_API_KEY=your-openai-api-key-here
+
+# Option 3: Anthropic
+# LLM_PROVIDER=anthropic
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# --- Model override (optional) ----------------------------------------------
+# Uncomment to use a specific model instead of the provider's default.
+# Defaults: gemini-2.5-flash, gpt-4o, claude-sonnet-4-20250514
+# LLM_MODEL=gemini-2.5-flash
+
+# --- API URLs ----------------------------------------------------------------
+# API_URL=http://localhost:8000
+
+# --- Langfuse observability (Labs 2 & 3) ------------------------------------
+# These defaults match the local docker-compose Langfuse instance.
+# LANGFUSE_PUBLIC_KEY=pk-lf-workshop
+# LANGFUSE_SECRET_KEY=sk-lf-workshop
+# LANGFUSE_HOST=http://localhost:3000
+
+# --- Granite Guardian via Ollama (Lab 3 grounding) ---------------------------
+# OLLAMA_BASE_URL=http://localhost:11434
+# GUARDIAN_MODEL=ibm/granite3.2-guardian:3b
+# MAX_REVISIONS=2

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,0 +1,60 @@
+"""
+Provider-swappable LLM factory for the workshop.
+
+All labs call get_chat_model() instead of importing a provider-specific class
+directly. Switching providers is a one-line .env change:
+
+    LLM_PROVIDER=gemini   # default — free tier, no credit card
+    LLM_PROVIDER=openai
+    LLM_PROVIDER=anthropic
+
+Each provider reads its own API key from the environment automatically
+(GOOGLE_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY). Set LLM_MODEL to
+override the default model for any provider.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from langchain_core.language_models.chat_models import BaseChatModel
+
+load_dotenv()
+
+_DEFAULT_MODELS = {
+    "gemini": "gemini-2.5-flash",
+    "openai": "gpt-4o",
+    "anthropic": "claude-sonnet-4-20250514",
+}
+
+
+def get_chat_model(**kwargs) -> BaseChatModel:
+    """Return a LangChain chat model for the configured provider.
+
+    Keyword arguments are forwarded to the underlying chat model constructor
+    (e.g. max_retries=3).
+    """
+    provider = os.environ.get("LLM_PROVIDER", "gemini").lower()
+    model = os.environ.get("LLM_MODEL", "") or _DEFAULT_MODELS.get(provider)
+
+    if model is None:
+        raise ValueError(
+            f"Unknown LLM_PROVIDER '{provider}'. "
+            f"Supported: {', '.join(_DEFAULT_MODELS)}"
+        )
+
+    if provider == "gemini":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        return ChatGoogleGenerativeAI(model=model, **kwargs)
+
+    if provider == "openai":
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(model=model, **kwargs)
+
+    if provider == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(model=model, **kwargs)
+
+    raise ValueError(
+        f"Unknown LLM_PROVIDER '{provider}'. "
+        f"Supported: {', '.join(_DEFAULT_MODELS)}"
+    )

--- a/app/llm.py
+++ b/app/llm.py
@@ -21,9 +21,9 @@ from langchain_core.language_models.chat_models import BaseChatModel
 load_dotenv()
 
 _DEFAULT_MODELS = {
-    "gemini": "gemini-2.5-flash",
-    "openai": "gpt-4o",
-    "anthropic": "claude-sonnet-4-20250514",
+    "gemini": "gemini-2.5-flash-lite",
+    "openai": "gpt-4o-mini",
+    "anthropic": "claude-haiku-4-5-20251001",
 }
 
 

--- a/docs/content/lab-1.md
+++ b/docs/content/lab-1.md
@@ -182,7 +182,7 @@ Open `lab1/agent/agent.py`. The core is surprisingly short:
 
 ```python
 def _build_agent():
-    llm = ChatOpenAI(model=MODEL)
+    llm = get_chat_model()
     return create_react_agent(
         model=llm,
         tools=ALL_TOOLS,
@@ -240,11 +240,7 @@ This is the **contract** between the agent and the UI. The agent fills it in; th
 
 ## Step 3: Run the Agent
 
-Make sure you have an OpenAI API key set:
-
-```bash
-export OPENAI_API_KEY=your-api-key-here
-```
+Make sure you've configured your LLM provider in `.env` (see [Prerequisites](./prerequisites.md#llm-provider-setup)).
 
 Start the agent API (in addition to the two terminals from Step 1):
 

--- a/docs/content/lab-3.md
+++ b/docs/content/lab-3.md
@@ -143,7 +143,7 @@ Before grounding, an LLM reads each concern's summary, action, and evidence fiel
 ```python
 @observe(name="Claim Extraction")
 def _extract_claims(title, summary, action, evidence) -> list[str]:
-    llm = ChatOpenAI(model=model).with_structured_output(ExtractedClaims)
+    llm = get_chat_model().with_structured_output(ExtractedClaims)
     return llm.invoke(_EXTRACT_PROMPT.format(...)).claims
 ```
 
@@ -158,12 +158,12 @@ Open `lab3/agent/grounding.py`. It takes the extracted claims and the tool outpu
 grounding_mode: str = "llm"
 ```
 
-The **LLM-as-judge** path sends the claims and tool output to the same OpenAI model:
+The **LLM-as-judge** path sends the claims and tool output to the configured LLM:
 
 ```python
 @observe(name="Grounding: LLM-as-Judge")
 def _check_llm_judge(claims: list[str], context: str) -> list[ClaimVerdict]:
-    llm = ChatOpenAI(model=model).with_structured_output(...)
+    llm = get_chat_model().with_structured_output(...)
     result = llm.invoke(_JUDGE_PROMPT.format(context=context, claims=...))
     return result.verdicts
 ```
@@ -193,7 +193,7 @@ Open `lab3/agent/critic.py`. The critic receives concerns plus grounding results
 
 ```python
 def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> CriticResult:
-    llm = ChatOpenAI(model=model).with_structured_output(CriticResult)
+    llm = get_chat_model().with_structured_output(CriticResult)
     return llm.invoke(_CRITIC_PROMPT.format(
         concerns=concerns_json,
         grounding=grounding_json,

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -172,8 +172,10 @@ The labs need an LLM API key. Pick **one** provider and install its dependencies
 === "Google Gemini (recommended)"
     **Free tier, no credit card required** — just a Google account.
 
-    1. Go to [Google AI Studio](https://aistudio.google.com/apikey) and create an API key
-    2. Install dependencies and configure your key:
+    1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
+    2. When prompted to select a project, use the **default project** (usually called "Default Gemini Project" or "Generative Language Client"). Don't create a new project — the Gemini API is already enabled on the default one.
+    3. Click **Create API key** and copy it
+    4. Install dependencies and configure your key:
 
     ```bash
     uv sync --extra gemini
@@ -182,6 +184,9 @@ The labs need an LLM API key. Pick **one** provider and install its dependencies
     ```
 
     The free tier is generous enough for a classroom of 30+ concurrent users.
+
+    !!! warning "Created a new Google Cloud project?"
+        If you created your key in a new project, you'll get an `API_KEY_INVALID` error. Either recreate the key in the default project, or enable the [Generative Language API](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) on your project.
 
 === "OpenAI"
     Requires an [OpenAI Platform](https://platform.openai.com/) account (pay-as-you-go).

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -73,7 +73,7 @@ uv sync
 
 ## 3. LLM Provider Setup
 
-The labs call LLMs via API. You need an API key from **one** provider. Labs 1 and 2 work on the Gemini free tier, but **Labs 3 and 4 make 10-15+ LLM calls per run** — more than free-tier rate limits allow. We recommend getting your own paid API key (OpenAI is the cheapest option — the entire workshop costs well under $1).
+The labs call LLMs via API. You need an API key from **one** provider. Labs 1 and 2 work on the Gemini free tier, but **Labs 3 and 4 make 10-15+ LLM calls per run** — more than free-tier rate limits allow. We recommend getting your own paid API key (OpenAI is the cheapest option — the entire workshop costs under $5).
 
 === "OpenAI (recommended)"
     The best option for the full workshop. Cheap, fast, high rate limits.
@@ -92,7 +92,7 @@ The labs call LLMs via API. You need an API key from **one** provider. Labs 1 an
     | | |
     |---|---|
     | **Model** | `gpt-4o-mini` (default) |
-    | **Cost** | ~$0.15 per 1M input tokens — the entire workshop costs well under $1 |
+    | **Cost** | ~$0.15 per 1M input tokens — the entire workshop costs under $5 |
     | **Rate limits** | 500+ requests/min (pay-as-you-go Tier 1) |
     | **Works for** | All labs |
 

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -66,6 +66,7 @@ Complete these steps **before the workshop** to make sure your environment is re
 ```bash
 git clone https://github.com/obuzek/ai-agents-workshop.git
 cd ai-agents-workshop
+uv sync
 ```
 
 ---

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -2,6 +2,93 @@
 
 Complete these steps **before the workshop** to make sure your environment is ready.
 
+## LLM Provider Setup
+
+The labs call LLMs via API. You need an API key from **one** provider. Labs 1 and 2 work on the Gemini free tier, but **Labs 3 and 4 make 10-15+ LLM calls per run** — more than free-tier rate limits allow. We recommend getting your own paid API key (OpenAI is the cheapest option — the entire workshop costs well under $1).
+
+=== "OpenAI (recommended)"
+    The best option for the full workshop. Cheap, fast, high rate limits.
+
+    1. Sign up at [platform.openai.com](https://platform.openai.com/)
+    2. Add a payment method (credit card required) and set a **usage limit** — $5 is more than enough for the entire workshop
+    3. Go to [API Keys](https://platform.openai.com/api-keys) and create a new secret key
+    4. Install dependencies and configure your key:
+
+    ```bash
+    uv sync --extra openai
+    cp .env-example .env
+    # Edit .env → uncomment the OpenAI section, set OPENAI_API_KEY=your-key
+    ```
+
+    | | |
+    |---|---|
+    | **Model** | `gpt-4o-mini` (default) |
+    | **Cost** | ~$0.15 per 1M input tokens — the entire workshop costs well under $1 |
+    | **Rate limits** | 500+ requests/min (pay-as-you-go Tier 1) |
+    | **Works for** | All labs |
+
+=== "Google Gemini (free)"
+    **Free tier, no credit card required** — just a Google account. Good for Labs 1 and 2.
+
+    1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
+    2. When prompted to select a project, use the **default project** (usually called "Default Gemini Project" or "Generative Language Client"). Don't create a new project — the Gemini API is already enabled on the default one.
+    3. Click **Create API key** and copy it
+    4. Install dependencies and configure your key:
+
+    ```bash
+    uv sync --extra gemini
+    cp .env-example .env
+    # Edit .env → set GOOGLE_API_KEY=your-key
+    ```
+
+    | | |
+    |---|---|
+    | **Model** | `gemini-2.5-flash-lite` (default) |
+    | **Cost** | Free |
+    | **Rate limits** | 15 requests/min, 1,000 requests/day |
+    | **Works for** | Labs 1-2 |
+
+    !!! warning "Created a new Google Cloud project?"
+        If you created your key in a new project, you'll get an `API_KEY_INVALID` error. Either recreate the key in the default project, or enable the [Generative Language API](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) on your project.
+
+    !!! warning "Rate limits for Labs 3+"
+        The free tier allows 15 requests per minute. Lab 3's multi-node agent (ReAct + grounding + critic) makes 10-15+ LLM calls per patient, so you'll hit rate limits. For Lab 3 onward, switch to a paid provider (OpenAI is recommended).
+
+=== "Anthropic"
+    1. Sign up at [console.anthropic.com](https://console.anthropic.com/)
+    2. Add a payment method and go to [API Keys](https://console.anthropic.com/settings/keys) to create a key
+    3. Install dependencies and configure your key:
+
+    ```bash
+    uv sync --extra anthropic
+    cp .env-example .env
+    # Edit .env → uncomment the Anthropic section, set ANTHROPIC_API_KEY=your-key
+    ```
+
+    | | |
+    |---|---|
+    | **Model** | `claude-haiku-4-5-20251001` (default) |
+    | **Cost** | ~$1 per 1M input tokens — the entire workshop should cost under $5 |
+    | **Rate limits** | 50+ requests/min (pay-as-you-go) |
+    | **Works for** | All labs |
+
+The total LLM cost for the entire workshop should not exceed **$5** on any paid provider. The workshop uses cheap, fast models — not frontier models — because the goal is learning agent patterns, not benchmarking LLM quality.
+
+See `.env-example` for all available configuration options.
+
+!!! tip "Switching providers mid-workshop"
+    Change `LLM_PROVIDER` and the API key in your `.env` file, then restart the agent. No code changes needed.
+
+???+ note "Other free-tier options"
+    If you don't want to pay for an API key, these providers offer free tiers with tool calling and structured output. They aren't pre-configured in `app/llm.py` but could be added.
+
+    | Provider | Free RPM | Free RPD | Best model | Catches |
+    |----------|---------|---------|------------|---------|
+    | [Groq](https://console.groq.com/) | 30 | 1,000 | `llama-4-scout-17b-16e-instruct` | 30K token/min limit; no credit card needed |
+    | [Cerebras](https://cloud.cerebras.ai/) | 30 | 14,400 | `llama-3.3-70b` | 8K context window cap — test whether your prompts fit |
+
+---
+
 ## Required for All Labs
 
 ### Python 3.11+
@@ -164,94 +251,6 @@ uv sync --extra postgres
 git clone https://github.com/obuzek/ai-agents-workshop.git
 cd ai-agents-workshop
 ```
-
-### LLM Provider Setup
-
-The labs need an LLM API key. Pick **one** provider and install its dependencies:
-
-=== "Google Gemini (free)"
-    **Free tier, no credit card required** — just a Google account. Good for Labs 1 and 2.
-
-    1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
-    2. When prompted to select a project, use the **default project** (usually called "Default Gemini Project" or "Generative Language Client"). Don't create a new project — the Gemini API is already enabled on the default one.
-    3. Click **Create API key** and copy it
-    4. Install dependencies and configure your key:
-
-    ```bash
-    uv sync --extra gemini
-    cp .env-example .env
-    # Edit .env → set GOOGLE_API_KEY=your-key
-    ```
-
-    | | |
-    |---|---|
-    | **Model** | `gemini-2.5-flash-lite` (default) |
-    | **Cost** | Free |
-    | **Rate limits** | 15 requests/min, 1,000 requests/day |
-    | **Works for** | Labs 1-2 |
-
-    !!! warning "Created a new Google Cloud project?"
-        If you created your key in a new project, you'll get an `API_KEY_INVALID` error. Either recreate the key in the default project, or enable the [Generative Language API](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) on your project.
-
-    !!! warning "Rate limits for Labs 3+"
-        The free tier allows 15 requests per minute. Lab 3's multi-node agent (ReAct + grounding + critic) makes 10-15+ LLM calls per patient, so you'll hit rate limits. For Lab 3 onward, switch to a paid provider (OpenAI is recommended). If using your own LLM key presents a hardship for you, please message the instructor for access to a shared key. This key will be revoked after the workshop.
-
-=== "OpenAI (recommended)"
-    The best option for the full workshop. Cheap, fast, high rate limits.
-
-    1. Sign up at [platform.openai.com](https://platform.openai.com/)
-    2. Add a payment method (credit card required) and set a **usage limit** — $5 is more than enough for the entire workshop
-    3. Go to [API Keys](https://platform.openai.com/api-keys) and create a new secret key
-    4. Install dependencies and configure your key:
-
-    ```bash
-    uv sync --extra openai
-    cp .env-example .env
-    # Edit .env → uncomment the OpenAI section, set OPENAI_API_KEY=your-key
-    ```
-
-    | | |
-    |---|---|
-    | **Model** | `gpt-4o-mini` (default) |
-    | **Cost** | ~$0.15 per 1M input tokens — the entire workshop costs well under $1 |
-    | **Rate limits** | 500+ requests/min (pay-as-you-go Tier 1) |
-    | **Works for** | All labs |
-
-=== "Anthropic"
-    1. Sign up at [console.anthropic.com](https://console.anthropic.com/)
-    2. Add a payment method and go to [API Keys](https://console.anthropic.com/settings/keys) to create a key
-    3. Install dependencies and configure your key:
-
-    ```bash
-    uv sync --extra anthropic
-    cp .env-example .env
-    # Edit .env → uncomment the Anthropic section, set ANTHROPIC_API_KEY=your-key
-    ```
-
-    | | |
-    |---|---|
-    | **Model** | `claude-haiku-4-5-20251001` (default) |
-    | **Cost** | ~$1 per 1M input tokens — the entire workshop should cost under $5 |
-    | **Rate limits** | 50+ requests/min (pay-as-you-go) |
-    | **Works for** | All labs |
-
-The total LLM cost for the entire workshop should not exceed **$5** on any paid provider. The workshop uses cheap, fast models — not frontier models — because the goal is learning agent patterns, not benchmarking LLM quality.
-
-See `.env-example` for all available configuration options.
-
-!!! tip "Switching providers mid-workshop"
-    Change `LLM_PROVIDER` and the API key in your `.env` file, then restart the agent. No code changes needed.
-
-???+ note "Other free-tier options"
-    If you don't want to pay for an API key, these providers offer free tiers with tool calling and structured output. They aren't pre-configured in `app/llm.py` but could be added.
-
-    | Provider | Free RPM | Free RPD | Best model | Catches |
-    |----------|---------|---------|------------|---------|
-    | [Groq](https://console.groq.com/) | 30 | 1,000 | `llama-4-scout-17b-16e-instruct` | 30K token/min limit; no credit card needed |
-    | [Cerebras](https://cloud.cerebras.ai/) | 30 | 14,400 | `llama-3.3-70b` | 8K context window cap — test whether your prompts fit |
-
-???+ note "Instructor note: shared API key"
-    The Gemini free tier works for Labs 1-2 but **will hit rate limits on Lab 3+** (10-15 RPM vs 10-15+ calls per agent run). Have a shared OpenAI API key ready for attendees who don't have their own paid key. Set a usage limit of $20 on the key (actual cost will be far less — `gpt-4o-mini` is ~$0.15/1M input tokens). Revoke the key after the workshop. Attendees switch by setting `LLM_PROVIDER=openai` and `OPENAI_API_KEY` in their `.env`.
 
 ## Start the EHR Inbox
 

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -163,8 +163,51 @@ uv sync --extra postgres
 ```bash
 git clone https://github.com/obuzek/ai-agents-workshop.git
 cd ai-agents-workshop
-uv sync
 ```
+
+### LLM Provider Setup
+
+The labs need an LLM API key. Pick **one** provider and install its dependencies:
+
+=== "Google Gemini (recommended)"
+    **Free tier, no credit card required** — just a Google account.
+
+    1. Go to [Google AI Studio](https://aistudio.google.com/apikey) and create an API key
+    2. Install dependencies and configure your key:
+
+    ```bash
+    uv sync --extra gemini
+    cp .env-example .env
+    # Edit .env → set GOOGLE_API_KEY=your-key
+    ```
+
+    The free tier is generous enough for a classroom of 30+ concurrent users.
+
+=== "OpenAI"
+    Requires an [OpenAI Platform](https://platform.openai.com/) account (pay-as-you-go).
+
+    ```bash
+    uv sync --extra openai
+    cp .env-example .env
+    # Edit .env → uncomment the OpenAI section, set OPENAI_API_KEY=your-key
+    ```
+
+=== "Anthropic"
+    Requires an [Anthropic Console](https://console.anthropic.com/) account (pay-as-you-go).
+
+    ```bash
+    uv sync --extra anthropic
+    cp .env-example .env
+    # Edit .env → uncomment the Anthropic section, set ANTHROPIC_API_KEY=your-key
+    ```
+
+See `.env-example` for all available configuration options.
+
+!!! tip "Switching providers mid-workshop"
+    Change `LLM_PROVIDER` and the API key in your `.env` file, then restart the agent. No code changes needed.
+
+???+ note "Instructor note: rate limits"
+    The Gemini free tier handles 30-40 concurrent users comfortably. If you hit rate limits mid-session, have attendees switch to a different provider — changing `LLM_PROVIDER` in `.env` is all it takes.
 
 ## Start the EHR Inbox
 

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -150,7 +150,7 @@ See `.env-example` for all available configuration options.
 After setting up your `.env` file, confirm the LLM is reachable:
 
 ```bash
-uv run python -c "from app.llm import get_chat_model; print(get_chat_model().invoke('Say hello in exactly three words.').content)"
+uv run python scripts/check_llm.py
 ```
 
 You should see a short greeting. If you get an authentication error, double-check your API key in `.env`.

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -169,7 +169,7 @@ cd ai-agents-workshop
 
 The labs need an LLM API key. Pick **one** provider and install its dependencies:
 
-=== "Google Gemini (recommended)"
+=== "Google Gemini (free)"
     **Free tier, no credit card required** — just a Google account. Good for Labs 1 and 2.
 
     1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
@@ -183,16 +183,26 @@ The labs need an LLM API key. Pick **one** provider and install its dependencies
     # Edit .env → set GOOGLE_API_KEY=your-key
     ```
 
-    Default model is `gemini-2.5-flash`. Set `LLM_MODEL=gemini-2.5-flash-lite` in `.env` for higher rate limits (15 RPM vs 10 RPM).
+    | | |
+    |---|---|
+    | **Model** | `gemini-2.5-flash-lite` (default) |
+    | **Cost** | Free |
+    | **Rate limits** | 15 requests/min, 1,000 requests/day |
+    | **Works for** | Labs 1-2 |
 
     !!! warning "Created a new Google Cloud project?"
         If you created your key in a new project, you'll get an `API_KEY_INVALID` error. Either recreate the key in the default project, or enable the [Generative Language API](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) on your project.
 
     !!! warning "Rate limits for Labs 3+"
-        The Gemini free tier allows 10-15 requests per minute. Lab 3's multi-node agent (ReAct + grounding + critic) makes 10-15+ LLM calls per patient, so you'll likely hit rate limits. For Lab 3 onward, use a paid provider or ask your instructor for a shared API key.
+        The free tier allows 15 requests per minute. Lab 3's multi-node agent (ReAct + grounding + critic) makes 10-15+ LLM calls per patient, so you'll hit rate limits. For Lab 3 onward, switch to a paid provider (OpenAI is recommended). If using your own LLM key presents a hardship for you, please message the instructor for access to a shared key. This key will be revoked after the workshop.
 
-=== "OpenAI"
-    Requires an [OpenAI Platform](https://platform.openai.com/) account (pay-as-you-go). Works well for all labs — GPT-4o is a few cents per run.
+=== "OpenAI (recommended)"
+    The best option for the full workshop. Cheap, fast, high rate limits.
+
+    1. Sign up at [platform.openai.com](https://platform.openai.com/)
+    2. Add a payment method (credit card required) and set a **usage limit** — $5 is more than enough for the entire workshop
+    3. Go to [API Keys](https://platform.openai.com/api-keys) and create a new secret key
+    4. Install dependencies and configure your key:
 
     ```bash
     uv sync --extra openai
@@ -200,8 +210,17 @@ The labs need an LLM API key. Pick **one** provider and install its dependencies
     # Edit .env → uncomment the OpenAI section, set OPENAI_API_KEY=your-key
     ```
 
+    | | |
+    |---|---|
+    | **Model** | `gpt-4o-mini` (default) |
+    | **Cost** | ~$0.15 per 1M input tokens — the entire workshop costs well under $1 |
+    | **Rate limits** | 500+ requests/min (pay-as-you-go Tier 1) |
+    | **Works for** | All labs |
+
 === "Anthropic"
-    Requires an [Anthropic Console](https://console.anthropic.com/) account (pay-as-you-go).
+    1. Sign up at [console.anthropic.com](https://console.anthropic.com/)
+    2. Add a payment method and go to [API Keys](https://console.anthropic.com/settings/keys) to create a key
+    3. Install dependencies and configure your key:
 
     ```bash
     uv sync --extra anthropic
@@ -209,24 +228,30 @@ The labs need an LLM API key. Pick **one** provider and install its dependencies
     # Edit .env → uncomment the Anthropic section, set ANTHROPIC_API_KEY=your-key
     ```
 
+    | | |
+    |---|---|
+    | **Model** | `claude-haiku-4-5-20251001` (default) |
+    | **Cost** | ~$1 per 1M input tokens — the entire workshop should cost under $5 |
+    | **Rate limits** | 50+ requests/min (pay-as-you-go) |
+    | **Works for** | All labs |
+
+The total LLM cost for the entire workshop should not exceed **$5** on any paid provider. The workshop uses cheap, fast models — not frontier models — because the goal is learning agent patterns, not benchmarking LLM quality.
+
 See `.env-example` for all available configuration options.
 
 !!! tip "Switching providers mid-workshop"
     Change `LLM_PROVIDER` and the API key in your `.env` file, then restart the agent. No code changes needed.
 
-???+ note "Free-tier alternatives"
-    If you don't want to pay for an API key, here are your options. All support tool calling and structured output.
+???+ note "Other free-tier options"
+    If you don't want to pay for an API key, these providers offer free tiers with tool calling and structured output. They aren't pre-configured in `app/llm.py` but could be added.
 
     | Provider | Free RPM | Free RPD | Best model | Catches |
     |----------|---------|---------|------------|---------|
-    | [Google Gemini](https://aistudio.google.com/apikey) | 10-15 | 250-1,000 | `gemini-2.5-flash-lite` | Enough for Labs 1-2; too slow for Lab 3+ |
     | [Groq](https://console.groq.com/) | 30 | 1,000 | `llama-4-scout-17b-16e-instruct` | 30K token/min limit; no credit card needed |
     | [Cerebras](https://cloud.cerebras.ai/) | 30 | 14,400 | `llama-3.3-70b` | 8K context window cap — test whether your prompts fit |
 
-    For Groq or Cerebras, you'll need to add a LangChain integration package and a new provider branch in `app/llm.py`. PRs welcome!
-
-???+ note "Instructor note: rate limits"
-    The Gemini free tier is fine for Labs 1-2 but **will hit rate limits on Lab 3+** (10-15 RPM vs 10-15+ calls per agent run). Plan to hand out a shared OpenAI API key with a usage cap ($20 covers a full classroom easily — GPT-4o costs a few cents per run). Attendees switch by setting `LLM_PROVIDER=openai` and `OPENAI_API_KEY` in their `.env`.
+???+ note "Instructor note: shared API key"
+    The Gemini free tier works for Labs 1-2 but **will hit rate limits on Lab 3+** (10-15 RPM vs 10-15+ calls per agent run). Have a shared OpenAI API key ready for attendees who don't have their own paid key. Set a usage limit of $20 on the key (actual cost will be far less — `gpt-4o-mini` is ~$0.15/1M input tokens). Revoke the key after the workshop. Attendees switch by setting `LLM_PROVIDER=openai` and `OPENAI_API_KEY` in their `.env`.
 
 ## Start the EHR Inbox
 

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -170,7 +170,7 @@ cd ai-agents-workshop
 The labs need an LLM API key. Pick **one** provider and install its dependencies:
 
 === "Google Gemini (recommended)"
-    **Free tier, no credit card required** — just a Google account.
+    **Free tier, no credit card required** — just a Google account. Good for Labs 1 and 2.
 
     1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
     2. When prompted to select a project, use the **default project** (usually called "Default Gemini Project" or "Generative Language Client"). Don't create a new project — the Gemini API is already enabled on the default one.
@@ -183,13 +183,16 @@ The labs need an LLM API key. Pick **one** provider and install its dependencies
     # Edit .env → set GOOGLE_API_KEY=your-key
     ```
 
-    The free tier is generous enough for a classroom of 30+ concurrent users.
+    Default model is `gemini-2.5-flash`. Set `LLM_MODEL=gemini-2.5-flash-lite` in `.env` for higher rate limits (15 RPM vs 10 RPM).
 
     !!! warning "Created a new Google Cloud project?"
         If you created your key in a new project, you'll get an `API_KEY_INVALID` error. Either recreate the key in the default project, or enable the [Generative Language API](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) on your project.
 
+    !!! warning "Rate limits for Labs 3+"
+        The Gemini free tier allows 10-15 requests per minute. Lab 3's multi-node agent (ReAct + grounding + critic) makes 10-15+ LLM calls per patient, so you'll likely hit rate limits. For Lab 3 onward, use a paid provider or ask your instructor for a shared API key.
+
 === "OpenAI"
-    Requires an [OpenAI Platform](https://platform.openai.com/) account (pay-as-you-go).
+    Requires an [OpenAI Platform](https://platform.openai.com/) account (pay-as-you-go). Works well for all labs — GPT-4o is a few cents per run.
 
     ```bash
     uv sync --extra openai
@@ -211,8 +214,19 @@ See `.env-example` for all available configuration options.
 !!! tip "Switching providers mid-workshop"
     Change `LLM_PROVIDER` and the API key in your `.env` file, then restart the agent. No code changes needed.
 
+???+ note "Free-tier alternatives"
+    If you don't want to pay for an API key, here are your options. All support tool calling and structured output.
+
+    | Provider | Free RPM | Free RPD | Best model | Catches |
+    |----------|---------|---------|------------|---------|
+    | [Google Gemini](https://aistudio.google.com/apikey) | 10-15 | 250-1,000 | `gemini-2.5-flash-lite` | Enough for Labs 1-2; too slow for Lab 3+ |
+    | [Groq](https://console.groq.com/) | 30 | 1,000 | `llama-4-scout-17b-16e-instruct` | 30K token/min limit; no credit card needed |
+    | [Cerebras](https://cloud.cerebras.ai/) | 30 | 14,400 | `llama-3.3-70b` | 8K context window cap — test whether your prompts fit |
+
+    For Groq or Cerebras, you'll need to add a LangChain integration package and a new provider branch in `app/llm.py`. PRs welcome!
+
 ???+ note "Instructor note: rate limits"
-    The Gemini free tier handles 30-40 concurrent users comfortably. If you hit rate limits mid-session, have attendees switch to a different provider — changing `LLM_PROVIDER` in `.env` is all it takes.
+    The Gemini free tier is fine for Labs 1-2 but **will hit rate limits on Lab 3+** (10-15 RPM vs 10-15+ calls per agent run). Plan to hand out a shared OpenAI API key with a usage cap ($20 covers a full classroom easily — GPT-4o costs a few cents per run). Attendees switch by setting `LLM_PROVIDER=openai` and `OPENAI_API_KEY` in their `.env`.
 
 ## Start the EHR Inbox
 

--- a/docs/content/prerequisites.md
+++ b/docs/content/prerequisites.md
@@ -2,7 +2,75 @@
 
 Complete these steps **before the workshop** to make sure your environment is ready.
 
-## LLM Provider Setup
+## 1. Install Tools
+
+### Python 3.11+
+
+=== "macOS"
+    ```bash
+    brew install python@3.11
+    python3 --version
+    ```
+
+=== "Linux"
+    ```bash
+    sudo apt update
+    sudo apt install python3.11 python3.11-venv
+    python3 --version
+    ```
+
+=== "Windows"
+    Download from [python.org](https://www.python.org/downloads/). Check "Add Python to PATH" during installation.
+
+### Git
+
+=== "macOS"
+    ```bash
+    brew install git
+    ```
+
+=== "Linux"
+    ```bash
+    sudo apt install git
+    ```
+
+=== "Windows"
+    Download from [git-scm.com](https://git-scm.com/download/win).
+
+### uv (Python package manager)
+
+=== "macOS/Linux"
+    ```bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    uv --version
+    ```
+
+=== "macOS (Homebrew)"
+    ```bash
+    brew install uv
+    uv --version
+    ```
+
+=== "Windows"
+    <!-- TODO: verify Windows uv install instructions (see issue) -->
+    ```powershell
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    uv --version
+    ```
+    Alternatively: `winget install --id=astral-sh.uv -e`
+
+---
+
+## 2. Clone and Install
+
+```bash
+git clone https://github.com/obuzek/ai-agents-workshop.git
+cd ai-agents-workshop
+```
+
+---
+
+## 3. LLM Provider Setup
 
 The labs call LLMs via API. You need an API key from **one** provider. Labs 1 and 2 work on the Gemini free tier, but **Labs 3 and 4 make 10-15+ LLM calls per run** — more than free-tier rate limits allow. We recommend getting your own paid API key (OpenAI is the cheapest option — the entire workshop costs well under $1).
 
@@ -76,6 +144,16 @@ The total LLM cost for the entire workshop should not exceed **$5** on any paid 
 
 See `.env-example` for all available configuration options.
 
+### Verify your API key
+
+After setting up your `.env` file, confirm the LLM is reachable:
+
+```bash
+uv run python -c "from app.llm import get_chat_model; print(get_chat_model().invoke('Say hello in exactly three words.').content)"
+```
+
+You should see a short greeting. If you get an authentication error, double-check your API key in `.env`.
+
 !!! tip "Switching providers mid-workshop"
     Change `LLM_PROVIDER` and the API key in your `.env` file, then restart the agent. No code changes needed.
 
@@ -89,66 +167,9 @@ See `.env-example` for all available configuration options.
 
 ---
 
-## Required for All Labs
+## 4. Later-Lab Prerequisites
 
-### Python 3.11+
-
-=== "macOS"
-    ```bash
-    brew install python@3.11
-    python3 --version
-    ```
-
-=== "Linux"
-    ```bash
-    sudo apt update
-    sudo apt install python3.11 python3.11-venv
-    python3 --version
-    ```
-
-=== "Windows"
-    Download from [python.org](https://www.python.org/downloads/). Check "Add Python to PATH" during installation.
-
-### Git
-
-=== "macOS"
-    ```bash
-    brew install git
-    ```
-
-=== "Linux"
-    ```bash
-    sudo apt install git
-    ```
-
-=== "Windows"
-    Download from [git-scm.com](https://git-scm.com/download/win).
-
-### uv (Python package manager)
-
-=== "macOS/Linux"
-    ```bash
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    uv --version
-    ```
-
-=== "macOS (Homebrew)"
-    ```bash
-    brew install uv
-    uv --version
-    ```
-
-=== "Windows"
-    <!-- TODO: verify Windows uv install instructions (see issue) -->
-    ```powershell
-    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-    uv --version
-    ```
-    Alternatively: `winget install --id=astral-sh.uv -e`
-
-## Required for Lab 2
-
-### Docker
+### Docker (Labs 2, 3, 4)
 
 Labs 2, 3, and 4 use Docker Compose for various services (Langfuse, Postgres). Install Docker before the workshop.
 
@@ -183,9 +204,7 @@ docker compose version
     docker pull postgres:16                              # Lab 4
     ```
 
-## Optional for Lab 3
-
-### Ollama + Granite Guardian
+### Ollama + Granite Guardian (Lab 3 — optional)
 
 Lab 3 includes a grounding check that compares LLM-as-judge vs. [Granite Guardian](https://www.ibm.com/granite/docs/models/guardian/). The Guardian path is **optional** — the lab works out of the box with LLM-as-judge grounding. If you want to compare both approaches:
 
@@ -214,9 +233,7 @@ ollama list | grep guardian
 ???+ tip "Why Ollama?"
     Granite Guardian runs locally — no API keys, no cloud dependency. Your patient data never leaves your machine, which matters when you're building hallucination detection for healthcare data.
 
-## Required for Lab 4
-
-### Postgres (via Docker)
+### Postgres via Docker (Lab 4)
 
 Lab 4 stores agent concerns in Postgres with Row-Level Security. The database runs in Docker — no local Postgres installation needed.
 
@@ -245,14 +262,7 @@ uv sync --extra postgres
 
 ---
 
-## Clone and Install
-
-```bash
-git clone https://github.com/obuzek/ai-agents-workshop.git
-cd ai-agents-workshop
-```
-
-## Start the EHR Inbox
+## 5. Start the EHR Inbox
 
 The workshop uses a simulated Electronic Health Record (EHR) inbox — a patient portal for **Lakeview Family Medicine**. Start it by running two commands in separate terminals:
 

--- a/lab1/agent/agent.py
+++ b/lab1/agent/agent.py
@@ -11,12 +11,12 @@ and structured output ensures we get valid JSON every time.
 """
 
 import logging
-import os
 from datetime import datetime, timezone
 
-# ChatOpenAI is LangChain's wrapper around the OpenAI chat API.
-# It reads OPENAI_API_KEY from the environment automatically.
-from langchain_openai import ChatOpenAI
+# get_chat_model() returns the LangChain chat model for whatever provider
+# is configured via LLM_PROVIDER env var (default: Gemini).
+# See app/llm.py for provider details and .env-example for configuration.
+from app.llm import get_chat_model
 
 # create_react_agent builds a full ReAct agent graph:
 #   1. Send messages to the LLM
@@ -29,9 +29,6 @@ from lab1.agent.tools import ALL_TOOLS
 from lab1.agent.models import PatientConcerns
 
 logger = logging.getLogger(__name__)
-
-# Which model to use — override with OPENAI_MODEL env var
-MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
 
 # The system prompt defines the agent's persona and output expectations.
 # This is the single most important piece of the agent — it controls what
@@ -82,13 +79,13 @@ def _build_agent():
     - The tools (what the LLM can do)
     - The response format (what shape the final answer must be)
     """
-    llm = ChatOpenAI(model=MODEL)
+    llm = get_chat_model()
     return create_react_agent(
         model=llm,
         tools=ALL_TOOLS,
         # The system prompt is injected at the start of every conversation
         prompt=SYSTEM_PROMPT,
-        # response_format tells LangGraph to use OpenAI's structured output
+        # response_format tells LangGraph to use the LLM's structured output
         # mode. After the agent finishes calling tools, LangGraph makes one
         # final LLM call with constrained decoding so the output is guaranteed
         # to be valid JSON matching our Pydantic model. No parsing needed.

--- a/lab2/agent/agent.py
+++ b/lab2/agent/agent.py
@@ -17,10 +17,9 @@ inside the ReAct loop — no manual instrumentation of individual steps needed.
 """
 
 import logging
-import os
 from datetime import datetime, timezone
 
-from langchain_openai import ChatOpenAI
+from app.llm import get_chat_model
 from langgraph.prebuilt import create_react_agent
 
 from lab2.agent.tools import ALL_TOOLS
@@ -28,8 +27,6 @@ from lab2.agent.models import PatientConcerns
 from lab2.agent.observability import create_langfuse_handler
 
 logger = logging.getLogger(__name__)
-
-MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
 
 # System prompt is identical to Lab 1 — we're adding observability,
 # not changing agent behavior.
@@ -72,7 +69,7 @@ OUTPUT RULES:
 
 def _build_agent():
     """Build the LangGraph ReAct agent (identical to Lab 1)."""
-    llm = ChatOpenAI(model=MODEL)
+    llm = get_chat_model()
     return create_react_agent(
         model=llm,
         tools=ALL_TOOLS,

--- a/lab3/agent/agent.py
+++ b/lab3/agent/agent.py
@@ -17,7 +17,7 @@ import os
 from datetime import datetime, timezone
 from typing import TypedDict
 
-from langchain_openai import ChatOpenAI
+from app.llm import get_chat_model
 from langfuse import observe
 from langfuse.langchain import CallbackHandler
 from langgraph.graph import StateGraph, START, END
@@ -31,7 +31,6 @@ from lab3.agent.critic import evaluate as critic_evaluate
 
 logger = logging.getLogger(__name__)
 
-MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
 MAX_REVISIONS = int(os.environ.get("MAX_REVISIONS", "2"))
 
 SYSTEM_PROMPT = """\
@@ -92,7 +91,7 @@ class ReviewState(TypedDict):
 
 
 _react_agent = create_react_agent(
-    model=ChatOpenAI(model=MODEL, max_retries=3),
+    model=get_chat_model(max_retries=3),
     tools=ALL_TOOLS,
     prompt=SYSTEM_PROMPT,
     response_format=PatientConcerns,

--- a/lab3/agent/critic.py
+++ b/lab3/agent/critic.py
@@ -13,9 +13,8 @@ This is a single LLM call with structured output — not a tool-calling agent.
 """
 
 import logging
-import os
 
-from langchain_openai import ChatOpenAI
+from app.llm import get_chat_model
 from langfuse import observe
 from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
@@ -78,8 +77,7 @@ def evaluate(concerns_json: str, grounding_results: list[GroundingResult]) -> Cr
     On failure (rate limits, timeouts), approves the output as-is —
     better to surface unreviewed concerns than to crash the run.
     """
-    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
-    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(CriticResult)
+    llm = get_chat_model(max_retries=3).with_structured_output(CriticResult)
 
     grounding_json = "\n".join(r.model_dump_json() for r in grounding_results)
 

--- a/lab3/agent/grounding.py
+++ b/lab3/agent/grounding.py
@@ -6,7 +6,7 @@ Three steps:
      and extracts every specific medical claim that needs verification.
   2. Grounding: each extracted claim is checked against the tool output.
      Two implementations behind a runtime toggle:
-       a. LLM-as-judge: the same OpenAI model evaluates groundedness.
+       a. LLM-as-judge: the configured LLM evaluates groundedness.
        b. Granite Guardian: a purpose-built IBM model via Ollama.
   3. Results are returned to the caller (the evaluate node) for the critic.
 
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 
-from langchain_openai import ChatOpenAI
+from app.llm import get_chat_model
 from langfuse import observe
 from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
@@ -105,8 +105,7 @@ Evidence: {evidence}
 @observe(name="Claim Extraction")
 def _extract_claims(title: str, summary: str, action: str, evidence: list[str]) -> list[str]:
     """Extract specific, verifiable medical claims from a concern."""
-    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
-    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(ExtractedClaims)
+    llm = get_chat_model(max_retries=3).with_structured_output(ExtractedClaims)
     handler = CallbackHandler()
     result = llm.invoke(
         _EXTRACT_PROMPT.format(
@@ -143,9 +142,8 @@ CLAIMS TO VERIFY:
 
 @observe(name="Grounding: LLM-as-Judge")
 def _check_llm_judge(claims: list[str], context: str) -> list[ClaimVerdict]:
-    """Use the same OpenAI model to evaluate groundedness."""
-    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
-    llm = ChatOpenAI(model=model, max_retries=3).with_structured_output(ClaimVerdicts)
+    """Use the configured LLM to evaluate groundedness."""
+    llm = get_chat_model(max_retries=3).with_structured_output(ClaimVerdicts)
     handler = CallbackHandler()
     result = llm.invoke(
         _JUDGE_PROMPT.format(context=context, claims=json.dumps(claims)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,19 @@ dependencies = [
     "uvicorn>=0.34",
     "streamlit>=1.45",
     "requests>=2.32",
-    "openai>=1.0",
     "langgraph>=0.4",
     "langchain>=0.3",
     "langchain-experimental>=0.3",
-    "langchain-openai>=0.3",
+    "python-dotenv>=1.0",
     "langfuse>=2.0",
     "presidio-analyzer>=2.2",
     "presidio-anonymizer>=2.2",
 ]
 
 [project.optional-dependencies]
+gemini = ["langchain-google-genai>=2.0"]
+openai = ["langchain-openai>=0.3", "openai>=1.0"]
+anthropic = ["langchain-anthropic>=0.3"]
 guardian = ["ollama>=0.4"]
 postgres = ["psycopg[binary]>=3.1", "psycopg_pool>=3.1"]
 

--- a/scripts/check_llm.py
+++ b/scripts/check_llm.py
@@ -1,0 +1,7 @@
+"""Quick check that your LLM provider is configured and reachable."""
+
+from app.llm import get_chat_model
+
+llm = get_chat_model()
+reply = llm.invoke("Say hello in exactly three words.")
+print(reply.content)

--- a/uv.lock
+++ b/uv.lock
@@ -21,20 +21,33 @@ dependencies = [
     { name = "fastapi" },
     { name = "langchain" },
     { name = "langchain-experimental" },
-    { name = "langchain-openai" },
     { name = "langfuse" },
     { name = "langgraph" },
-    { name = "openai" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
+    { name = "python-dotenv" },
     { name = "requests" },
     { name = "streamlit" },
     { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
+anthropic = [
+    { name = "langchain-anthropic" },
+]
+gemini = [
+    { name = "langchain-google-genai" },
+]
 guardian = [
     { name = "ollama" },
+]
+openai = [
+    { name = "langchain-openai" },
+    { name = "openai" },
+]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
 ]
 
 [package.dev-dependencies]
@@ -46,19 +59,24 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "langchain", specifier = ">=0.3" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=0.3" },
     { name = "langchain-experimental", specifier = ">=0.3" },
-    { name = "langchain-openai", specifier = ">=0.3" },
+    { name = "langchain-google-genai", marker = "extra == 'gemini'", specifier = ">=2.0" },
+    { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.3" },
     { name = "langfuse", specifier = ">=2.0" },
     { name = "langgraph", specifier = ">=0.4" },
     { name = "ollama", marker = "extra == 'guardian'", specifier = ">=0.4" },
-    { name = "openai", specifier = ">=1.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "presidio-analyzer", specifier = ">=2.2" },
     { name = "presidio-anonymizer", specifier = ">=2.2" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
+    { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.1" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.32" },
     { name = "streamlit", specifier = ">=1.45" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
-provides-extras = ["guardian"]
+provides-extras = ["gemini", "openai", "anthropic", "guardian", "postgres"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]
@@ -219,6 +237,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.97.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
 ]
 
 [[package]]
@@ -663,6 +700,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -685,6 +731,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
 
 [[package]]
@@ -814,6 +869,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -1116,6 +1210,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-anthropic"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/19/55e0d3548a4d85ccee630fcfc0979af54ff4ea4f39ab0ed1ed3c6bf25f4e/langchain_anthropic-1.4.1.tar.gz", hash = "sha256:e17d027091438620e35ff2f06aefdfd63c8dcdf6abc606009ddfe3c764f2bc2e", size = 676043, upload-time = "2026-04-17T14:26:17.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/0a/20625dfea38a26e8b43654e18cafbc3595e7dc223da80f23d4fa8451dc1d/langchain_anthropic-1.4.1-py3-none-any.whl", hash = "sha256:5a48afbb2b1bad9c46badaccc8e23b0dd7ae07b7583f76bac21ddb3dac831efd", size = 49020, upload-time = "2026-04-17T14:26:15.989Z" },
+]
+
+[[package]]
 name = "langchain-classic"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +1295,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/ec/6fe7b2e3c105b4f4fc6b943d8fc1b5b10f883429edc36c58a09fc2e28419/langchain_experimental-0.4.1.tar.gz", hash = "sha256:ab6b19a0b98fbc15225fbfcf096176fec339b7e3e930bcf328bb717985fc1da5", size = 170449, upload-time = "2025-12-11T05:30:48.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/fa/fb2c8b6418e1c9ef50c82b3b6e0184bce321582577240bb4b8ed3274a4aa/langchain_experimental-0.4.1-py3-none-any.whl", hash = "sha256:b6ee2f42b50aaadb45e581439ecf5ee50f3a6a0986d52e74d1e64721309e387d", size = 210096, upload-time = "2025-12-11T05:30:47.234Z" },
+]
+
+[[package]]
+name = "langchain-google-genai"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filetype" },
+    { name = "google-genai" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/78/dfe068937338727b0dee637d971d59fe2fa275f9d0f0edee3fa80e811846/langchain_google_genai-4.2.2.tar.gz", hash = "sha256:5fc774bf41d1dc1c1a5ba8d7b9f2017dfa77e30653c9b44d2dfbaf0e877e7388", size = 267457, upload-time = "2026-04-15T15:08:32.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/5c/adf81d68ab89b4cf505e690f8c1956d11b5969c831c951c7b4b1b1818080/langchain_google_genai-4.2.2-py3-none-any.whl", hash = "sha256:c8d09aac0304d26f1c2483e41a350f15587af1fbe034c39a304e1e17a3b743f3", size = 67605, upload-time = "2026-04-15T15:08:31.346Z" },
 ]
 
 [[package]]
@@ -2297,6 +2420,87 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/c0/b389119dd754483d316805260f3e73cdcad97925839107cc7a296f6132b1/psycopg_binary-3.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a89bb9ee11177b2995d87186b1d9fa892d8ea725e85eab28c6525e4cc14ee048", size = 4609740, upload-time = "2026-02-18T16:47:51.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9976eef20f61840285174d360da4c820a311ab39d6b82fa09fbb545be825/psycopg_binary-3.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f7d0cf072c6fbac3795b08c98ef9ea013f11db609659dcfc6b1f6cc31f9e181", size = 4676837, upload-time = "2026-02-18T16:47:55.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/d28ba2f7404fd7f68d41e8a11df86313bd646258244cb12a8dd83b868a97/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:90eecd93073922f085967f3ed3a98ba8c325cbbc8c1a204e300282abd2369e13", size = 5497070, upload-time = "2026-02-18T16:47:59.929Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/6c5c54b815edeb30a281cfcea96dc93b3bb6be939aea022f00cab7aa1420/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dac7ee2f88b4d7bb12837989ca354c38d400eeb21bce3b73dac02622f0a3c8d6", size = 5172410, upload-time = "2026-02-18T16:48:05.665Z" },
+    { url = "https://files.pythonhosted.org/packages/51/75/8206c7008b57de03c1ada46bd3110cc3743f3fd9ed52031c4601401d766d/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b62cf8784eb6d35beaee1056d54caf94ec6ecf2b7552395e305518ab61eb8fd2", size = 6763408, upload-time = "2026-02-18T16:48:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/ea1641a1e6c8c8b3454b0fcb43c3045133a8b703e6e824fae134088e63bd/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a39f34c9b18e8f6794cca17bfbcd64572ca2482318db644268049f8c738f35a6", size = 5006255, upload-time = "2026-02-18T16:48:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fb/538df099bf55ae1637d52d7ccb6b9620b535a40f4c733897ac2b7bb9e14c/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:883d68d48ca9ff3cb3d10c5fdebea02c79b48eecacdddbf7cce6e7cdbdc216b8", size = 4532694, upload-time = "2026-02-18T16:48:27.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d1/00780c0e187ea3c13dfc53bd7060654b2232cd30df562aac91a5f1c545ac/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cab7bc3d288d37a80aa8c0820033250c95e40b1c2b5c57cf59827b19c2a8b69d", size = 4222833, upload-time = "2026-02-18T16:48:31.221Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/a07f1ff713c51d64dc9f19f2c32be80299a2055d5d109d5853662b922cb4/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:56c767007ca959ca32f796b42379fc7e1ae2ed085d29f20b05b3fc394f3715cc", size = 3952818, upload-time = "2026-02-18T16:48:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/67/d33f268a7759b4445f3c9b5a181039b01af8c8263c865c1be7a6444d4749/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:da2f331a01af232259a21573a01338530c6016dcfad74626c01330535bcd8628", size = 4258061, upload-time = "2026-02-18T16:48:41.365Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3b/0d8d2c5e8e29ccc07d28c8af38445d9d9abcd238d590186cac82ee71fc84/psycopg_binary-3.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:19f93235ece6dbfc4036b5e4f6d8b13f0b8f2b3eeb8b0bd2936d406991bcdd40", size = 3558915, upload-time = "2026-02-18T16:48:46.679Z" },
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2344,6 +2548,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -3477,6 +3702,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713, upload-time = "2026-03-20T08:10:23.637Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `app/llm.py` — a provider factory that reads `LLM_PROVIDER` env var and returns the appropriate LangChain chat model (Gemini, OpenAI, or Anthropic)
- Updates all 3 labs to use `get_chat_model()` instead of hardcoded `ChatOpenAI`
- Moves provider-specific packages to optional dependency groups (`uv sync --extra gemini`)
- Adds `.env-example` with documented configuration for all providers
- Updates prerequisites docs with provider setup instructions (Gemini as recommended default — free, no credit card)

## Changed files

| File | Change |
|------|--------|
| `app/llm.py` | New — provider factory with dotenv loading |
| `.env-example` | New — all env vars documented by provider |
| `lab1/agent/agent.py` | `ChatOpenAI` → `get_chat_model()` |
| `lab2/agent/agent.py` | `ChatOpenAI` → `get_chat_model()` |
| `lab3/agent/agent.py` | `ChatOpenAI` → `get_chat_model()` |
| `lab3/agent/critic.py` | `ChatOpenAI` → `get_chat_model()` |
| `lab3/agent/grounding.py` | `ChatOpenAI` → `get_chat_model()` (LLM-as-judge only; Guardian stays on Ollama) |
| `pyproject.toml` | Provider packages → optional extras; added `python-dotenv` |
| `docs/content/prerequisites.md` | LLM provider setup section with tabbed instructions |
| `docs/content/lab-1.md` | Updated code snippets and env var references |
| `docs/content/lab-3.md` | Updated code snippets |

## Test plan

- [x] `uv sync --extra gemini` installs cleanly
- [x] `uv sync --extra openai` installs cleanly
- [x] `uv sync --extra anthropic` installs cleanly
- [x] Lab 1 agent runs with `LLM_PROVIDER=gemini`
- [x] Lab 2 agent runs with Langfuse tracing intact
- [x] Lab 3 agent runs (grounding + critic) with non-OpenAI provider
- [x] Switching `LLM_PROVIDER` in `.env` changes the model without code changes

Fixes #17

---
> 🤖 Generated by **claude** · AI-assisted workflow